### PR TITLE
feat: add initial client scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build outputs
+dist/
+build/
+
+# OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ There should be a docker-compose file which can serve the front-end using npx ht
 The server should have proper tests for all functionality and tests should spin up a new clean DB for each test run.
 
 
+
+## Client
+
+A minimal client scaffold is available under `client/`. Open `client/index.html` in a browser to see the placeholder interface.

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1,0 +1,18 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #f4f4f4;
+  color: #333;
+}
+
+h1 {
+  text-align: center;
+  padding-top: 2rem;
+}
+
+#app {
+  margin: 2rem auto;
+  width: 90%;
+  max-width: 600px;
+  text-align: center;
+}

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Whimsical</title>
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <h1>Whimsical</h1>
+  <div id="app"></div>
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -1,0 +1,6 @@
+function init() {
+  const app = document.getElementById('app');
+  app.textContent = 'Explore the stars!';
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- scaffold the client with HTML, CSS, and JavaScript files
- document new client structure in README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68906fed9540832aa2f8abb1d38d190e