### PR TITLE
feat: separate star and planet generation

### DIFF
--- a/client/js/galaxy.js
+++ b/client/js/galaxy.js
@@ -1,21 +1,14 @@
+import { generateStar } from './star.js';
+import { generatePlanet } from './planet.js';
+
 export function generateStarSystem() {
-  const STAR_TYPES = [
-    { name: 'red dwarf', color: '#ff4d4d', size: 2 },
-    { name: 'yellow star', color: '#ffd700', size: 3 },
-    { name: 'blue giant', color: '#4d79ff', size: 4 }
-  ];
-
-  const stars = Array.from(
-    { length: randomInt(1, 3) },
-    () => STAR_TYPES[randomInt(0, STAR_TYPES.length - 1)]
-  );
-
+  const star = generateStar();
+  const planetCount = randomInt(0, 10);
   const planets = Array.from(
-    { length: randomInt(0, 10) },
-    () => ({ type: Math.random() < 0.5 ? 'rocky' : 'gas' })
+    { length: planetCount },
+    (_, i) => generatePlanet(star, i)
   );
-
-  return { stars, planets };
+  return { stars: [star], planets };
 }
 
 export function generateGalaxy(size = 100, chance = 0.1) {

--- a/client/js/planet.js
+++ b/client/js/planet.js
@@ -1,0 +1,21 @@
+export function generatePlanet(star, orbitIndex) {
+  const distance = (orbitIndex + 1) * randomRange(0.3, 1.5); // in AU
+  const type = distance < star.habitableZone[0]
+    ? 'rocky'
+    : distance <= star.habitableZone[1]
+    ? 'rocky'
+    : 'gas';
+  const radius = type === 'rocky'
+    ? randomRange(0.3, 2)
+    : randomRange(3, 12);
+  const temperature = 278 * Math.pow(star.luminosity, 0.25) / Math.sqrt(distance);
+  const isHabitable = type === 'rocky' &&
+    distance >= star.habitableZone[0] &&
+    distance <= star.habitableZone[1];
+  const orbitalPeriod = Math.sqrt(Math.pow(distance, 3) / star.mass); // in Earth years
+  return { type, distance, radius, temperature, isHabitable, orbitalPeriod };
+}
+
+function randomRange(min, max) {
+  return Math.random() * (max - min) + min;
+}

--- a/client/js/star.js
+++ b/client/js/star.js
@@ -1,0 +1,50 @@
+const STAR_TYPES = [
+  {
+    name: 'red dwarf',
+    color: '#ff4d4d',
+    size: 2,
+    mass: [0.1, 0.5],
+    luminosity: [0.001, 0.08],
+    radius: [0.1, 0.6],
+    habitableZone: [0.05, 0.4]
+  },
+  {
+    name: 'yellow star',
+    color: '#ffd700',
+    size: 3,
+    mass: [0.8, 1.2],
+    luminosity: [0.6, 1.5],
+    radius: [0.9, 1.1],
+    habitableZone: [0.8, 1.5]
+  },
+  {
+    name: 'blue giant',
+    color: '#4d79ff',
+    size: 4,
+    mass: [10, 50],
+    luminosity: [10000, 100000],
+    radius: [4, 10],
+    habitableZone: [10, 100]
+  }
+];
+
+export function generateStar() {
+  const type = STAR_TYPES[randomInt(0, STAR_TYPES.length - 1)];
+  return {
+    name: type.name,
+    color: type.color,
+    size: type.size,
+    mass: randomRange(type.mass[0], type.mass[1]),
+    luminosity: randomRange(type.luminosity[0], type.luminosity[1]),
+    radius: randomRange(type.radius[0], type.radius[1]),
+    habitableZone: type.habitableZone
+  };
+}
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randomRange(min, max) {
+  return Math.random() * (max - min) + min;
+}


### PR DESCRIPTION
## Summary
- add star generator with mass, luminosity, radius and habitable zone ranges
- add planet generator that uses star data and orbital distance for type, temperature and habitability
- refactor galaxy generator to assemble systems from new star and planet modules

## Testing
- `node --input-type=module -e "import('./client/js/galaxy.js').then(({generateStarSystem}) => console.log(JSON.stringify(generateStarSystem(), null, 2)))"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68909e961328832a8bc06b209f6cf9dc