### PR TITLE
Expand celestial variety

### DIFF
--- a/client/js/galaxy.js
+++ b/client/js/galaxy.js
@@ -11,7 +11,7 @@ export function generateStarSystem() {
   return { stars: [star], planets };
 }
 
-export function generateGalaxy(size = 100, chance = 0.1) {
+export function generateGalaxy(size = 100, chance = 0.01) {
   const systems = [];
   for (let x = -size; x <= size; x++) {
     for (let y = -size; y <= size; y++) {

--- a/client/js/planet.js
+++ b/client/js/planet.js
@@ -1,17 +1,33 @@
 export function generatePlanet(star, orbitIndex) {
   const distance = (orbitIndex + 1) * randomRange(0.3, 1.5); // in AU
-  const type = distance < star.habitableZone[0]
-    ? 'rocky'
-    : distance <= star.habitableZone[1]
-    ? 'rocky'
-    : 'gas';
-  const radius = type === 'rocky'
-    ? randomRange(0.3, 2)
-    : randomRange(3, 12);
+  const inner = star.habitableZone[0];
+  const outer = star.habitableZone[1];
+
+  let type;
+  if (distance < inner * 0.5) {
+    type = 'lava';
+  } else if (distance < inner) {
+    type = 'rocky';
+  } else if (distance <= outer) {
+    type = 'terrestrial';
+  } else if (distance <= outer * 2) {
+    type = 'ice';
+  } else {
+    type = 'gas giant';
+  }
+
+  let radius;
+  if (type === 'gas giant') {
+    radius = randomRange(3, 12);
+  } else if (type === 'ice') {
+    radius = randomRange(0.5, 3);
+  } else {
+    radius = randomRange(0.3, 2);
+  }
+
   const temperature = 278 * Math.pow(star.luminosity, 0.25) / Math.sqrt(distance);
-  const isHabitable = type === 'rocky' &&
-    distance >= star.habitableZone[0] &&
-    distance <= star.habitableZone[1];
+  const isHabitable =
+    type === 'terrestrial' && distance >= inner && distance <= outer;
   const orbitalPeriod = Math.sqrt(Math.pow(distance, 3) / star.mass); // in Earth years
   return { type, distance, radius, temperature, isHabitable, orbitalPeriod };
 }

--- a/client/js/star.js
+++ b/client/js/star.js
@@ -1,30 +1,66 @@
 const STAR_TYPES = [
   {
-    name: 'red dwarf',
+    name: 'O-type star',
+    color: '#9bbcff',
+    size: 5,
+    mass: [16, 100],
+    luminosity: [30000, 1000000],
+    radius: [6.6, 15],
+    habitableZone: [100, 1000]
+  },
+  {
+    name: 'B-type star',
+    color: '#aabfff',
+    size: 4,
+    mass: [2.1, 16],
+    luminosity: [25, 30000],
+    radius: [1.8, 6.6],
+    habitableZone: [5, 100]
+  },
+  {
+    name: 'A-type star',
+    color: '#cad8ff',
+    size: 4,
+    mass: [1.4, 2.1],
+    luminosity: [5, 25],
+    radius: [1.4, 1.8],
+    habitableZone: [2, 5]
+  },
+  {
+    name: 'F-type star',
+    color: '#f8f7ff',
+    size: 3,
+    mass: [1.04, 1.4],
+    luminosity: [1.5, 5],
+    radius: [1.15, 1.4],
+    habitableZone: [1.3, 2.2]
+  },
+  {
+    name: 'G-type star',
+    color: '#fff4e8',
+    size: 3,
+    mass: [0.8, 1.04],
+    luminosity: [0.6, 1.5],
+    radius: [0.9, 1.15],
+    habitableZone: [0.95, 1.4]
+  },
+  {
+    name: 'K-type star',
+    color: '#ffd1a3',
+    size: 2,
+    mass: [0.45, 0.8],
+    luminosity: [0.08, 0.6],
+    radius: [0.7, 0.96],
+    habitableZone: [0.38, 0.8]
+  },
+  {
+    name: 'M-type star',
     color: '#ff4d4d',
     size: 2,
-    mass: [0.1, 0.5],
-    luminosity: [0.001, 0.08],
-    radius: [0.1, 0.6],
-    habitableZone: [0.05, 0.4]
-  },
-  {
-    name: 'yellow star',
-    color: '#ffd700',
-    size: 3,
-    mass: [0.8, 1.2],
-    luminosity: [0.6, 1.5],
-    radius: [0.9, 1.1],
-    habitableZone: [0.8, 1.5]
-  },
-  {
-    name: 'blue giant',
-    color: '#4d79ff',
-    size: 4,
-    mass: [10, 50],
-    luminosity: [10000, 100000],
-    radius: [4, 10],
-    habitableZone: [10, 100]
+    mass: [0.08, 0.45],
+    luminosity: [0.0001, 0.08],
+    radius: [0.1, 0.7],
+    habitableZone: [0.02, 0.4]
   }
 ];
 


### PR DESCRIPTION
## Summary
- Reduce default star probability per galaxy cell to 1%
- Diversify planet generation with lava, rocky, terrestrial, ice and gas giant types
- Introduce O–M stellar classes with corresponding colors and habitable zones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890abdd952c832ab4397c6615e56ab6