### PR TITLE
Add star system view and expand galaxy

### DIFF
--- a/client/js/components/overview.js
+++ b/client/js/components/overview.js
@@ -13,11 +13,11 @@ export function createOverview(onSelect) {
   const scaleX = overview.width / (size * 2 + 1);
   const scaleY = overview.height / (size * 2 + 1);
 
-  const stars = galaxy.systems.map(({ x, y, system }) => {
+  const systems = galaxy.systems.map(({ x, y, system }) => {
     const star = system.stars[0];
     const cx = (x + size) * scaleX;
     const cy = (y + size) * scaleY;
-    return { cx, cy, star };
+    return { cx, cy, star, system };
   });
 
   let hoveredIndex = null;
@@ -26,7 +26,7 @@ export function createOverview(onSelect) {
     ctx.fillStyle = '#000';
     ctx.fillRect(0, 0, overview.width, overview.height);
 
-    stars.forEach(({ cx, cy, star }, idx) => {
+    systems.forEach(({ cx, cy, star }, idx) => {
       ctx.beginPath();
       ctx.fillStyle = star.color;
       ctx.arc(cx, cy, star.size, 0, Math.PI * 2);
@@ -48,7 +48,7 @@ export function createOverview(onSelect) {
     const scaleY = overview.height / rect.height;
     const x = (event.clientX - rect.left) * scaleX;
     const y = (event.clientY - rect.top) * scaleY;
-    return stars.findIndex(({ cx, cy, star }) => {
+    return systems.findIndex(({ cx, cy, star }) => {
       const dx = cx - x;
       const dy = cy - y;
       return Math.sqrt(dx * dx + dy * dy) <= star.size;
@@ -68,7 +68,7 @@ export function createOverview(onSelect) {
   overview.addEventListener('click', (e) => {
     const idx = getStarIndex(e);
     if (idx !== -1 && typeof onSelect === 'function') {
-      onSelect(stars[idx].star);
+      onSelect(systems[idx].system);
     }
   });
 

--- a/client/js/components/star-sidebar.js
+++ b/client/js/components/star-sidebar.js
@@ -1,4 +1,5 @@
-export function createStarSidebar(star) {
+export function createStarSidebar(system, onGoToSystem) {
+  const star = system.stars[0];
   const container = document.createElement('div');
   container.className = 'star-sidebar';
   container.innerHTML = `
@@ -11,6 +12,15 @@ export function createStarSidebar(star) {
       <li><strong>Habitable Zone:</strong> ${star.habitableZone[0].toFixed(2)} - ${star.habitableZone[1].toFixed(2)} AU</li>
     </ul>
   `;
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Go to system';
+  btn.addEventListener('click', () => {
+    if (typeof onGoToSystem === 'function') {
+      onGoToSystem(system);
+    }
+  });
+  container.appendChild(btn);
   return container;
 }
 

--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -1,0 +1,82 @@
+const PLANET_COLORS = {
+  lava: '#ff4500',
+  rocky: '#b0b0b0',
+  terrestrial: '#2ecc71',
+  ice: '#87cefa',
+  'gas giant': '#f1c40f'
+};
+
+export function createSystemOverview(system, onBack) {
+  const container = document.createElement('div');
+  container.className = 'system-overview';
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 400;
+  canvas.height = 400;
+  const ctx = canvas.getContext('2d');
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const star = system.stars[0];
+  const planets = system.planets;
+  const maxDistance = Math.max(...planets.map(p => p.distance), 1);
+  const scale = (canvas.width / 2 - 20) / maxDistance;
+
+  function draw() {
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    planets.forEach((planet) => {
+      const orbitRadius = planet.distance * scale;
+      ctx.beginPath();
+      ctx.strokeStyle = '#444';
+      ctx.arc(cx, cy, orbitRadius, 0, Math.PI * 2);
+      ctx.stroke();
+
+      const px = cx + orbitRadius;
+      const py = cy;
+      const planetRadius = Math.max(2, planet.radius * 3);
+      ctx.beginPath();
+      ctx.fillStyle = PLANET_COLORS[planet.type] || '#fff';
+      ctx.arc(px, py, planetRadius, 0, Math.PI * 2);
+      ctx.fill();
+
+      if (planet.features) {
+        let iconX = px + planetRadius + 4;
+        const iconY = py;
+        planet.features.forEach((f) => {
+          ctx.fillStyle = '#fff';
+          if (f === 'base') {
+            ctx.fillRect(iconX, iconY - 2, 4, 4);
+          } else if (f === 'mine') {
+            ctx.beginPath();
+            ctx.moveTo(iconX, iconY - 3);
+            ctx.lineTo(iconX + 4, iconY - 3);
+            ctx.lineTo(iconX + 2, iconY + 1);
+            ctx.fill();
+          }
+          iconX += 6;
+        });
+      }
+    });
+
+    ctx.beginPath();
+    ctx.fillStyle = star.color;
+    ctx.arc(cx, cy, star.size * 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  draw();
+
+  const backBtn = document.createElement('button');
+  backBtn.textContent = 'Back';
+  backBtn.addEventListener('click', () => {
+    if (typeof onBack === 'function') {
+      onBack();
+    }
+  });
+
+  container.append(canvas, backBtn);
+  return container;
+}
+

--- a/client/js/galaxy.js
+++ b/client/js/galaxy.js
@@ -11,7 +11,7 @@ export function generateStarSystem() {
   return { stars: [star], planets };
 }
 
-export function generateGalaxy(size = 100, chance = 0.01) {
+export function generateGalaxy(size = 500, chance = 0.01) {
   const systems = [];
   for (let x = -size; x <= size; x++) {
     for (let y = -size; y <= size; y++) {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -2,6 +2,7 @@ import { createHeader } from './components/header.js';
 import { createOverview } from './components/overview.js';
 import { createSidebar, setSidebarContent } from './components/sidebar.js';
 import { createStarSidebar } from './components/star-sidebar.js';
+import { createSystemOverview } from './components/system-overview.js';
 
 function init() {
   const app = document.getElementById('app');
@@ -11,12 +12,29 @@ function init() {
   main.id = 'main';
 
   const sidebar = createSidebar();
-  const overview = createOverview((star) => {
-    const starContent = createStarSidebar(star);
-    setSidebarContent(sidebar, starContent);
-  });
+  let overview;
 
-  main.append(overview, sidebar);
+  function showGalaxy() {
+    const galaxyOverview = createOverview((system) => {
+      const starContent = createStarSidebar(system, showSystem);
+      setSidebarContent(sidebar, starContent);
+    });
+    if (overview) {
+      main.replaceChild(galaxyOverview, overview);
+    } else {
+      main.append(galaxyOverview);
+    }
+    overview = galaxyOverview;
+  }
+
+  function showSystem(system) {
+    const systemView = createSystemOverview(system, showGalaxy);
+    main.replaceChild(systemView, overview);
+    overview = systemView;
+  }
+
+  showGalaxy();
+  main.append(sidebar);
   app.append(header, main);
 }
 

--- a/client/js/planet.js
+++ b/client/js/planet.js
@@ -12,13 +12,17 @@ export function generatePlanet(star, orbitIndex) {
     distance >= star.habitableZone[0] &&
     distance <= star.habitableZone[1];
   const orbitalPeriod = Math.sqrt(Math.pow(distance, 3) / star.mass); // in Earth years
+  const features = [];
+  if (Math.random() < 0.1) features.push('base');
+  if (Math.random() < 0.1) features.push('mine');
   return {
     type: rule.name,
     distance,
     radius,
     temperature,
     isHabitable,
-    orbitalPeriod
+    orbitalPeriod,
+    features
   };
 }
 


### PR DESCRIPTION
## Summary
- enlarge galaxy generation to 1000x1000 grid
- add system overview with orbiting planets and feature icons
- allow jumping from star details to system view and back

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check client/js/galaxy.js client/js/components/overview.js client/js/components/star-sidebar.js client/js/main.js client/js/planet.js client/js/components/system-overview.js`

------
https://chatgpt.com/codex/tasks/task_e_6890c7eb214c832a90cf5e71c8d37aa1