### PR TITLE
Enable planet interactions and system view

### DIFF
--- a/client/js/components/overview.js
+++ b/client/js/components/overview.js
@@ -1,6 +1,6 @@
 import { generateGalaxy } from '../galaxy.js';
 
-export function createOverview(onSelect) {
+export function createOverview(onSelect, onOpenSystem) {
   const overview = document.createElement('canvas');
   overview.id = 'overview';
   overview.width = 400;
@@ -65,10 +65,23 @@ export function createOverview(onSelect) {
     draw();
   });
 
+  let clickTimeout;
+
   overview.addEventListener('click', (e) => {
+    clearTimeout(clickTimeout);
+    clickTimeout = setTimeout(() => {
+      const idx = getStarIndex(e);
+      if (idx !== -1 && typeof onSelect === 'function') {
+        onSelect(systems[idx].system);
+      }
+    }, 200);
+  });
+
+  overview.addEventListener('dblclick', (e) => {
+    clearTimeout(clickTimeout);
     const idx = getStarIndex(e);
-    if (idx !== -1 && typeof onSelect === 'function') {
-      onSelect(systems[idx].system);
+    if (idx !== -1 && typeof onOpenSystem === 'function') {
+      onOpenSystem(systems[idx].system);
     }
   });
 

--- a/client/js/components/planet-sidebar.js
+++ b/client/js/components/planet-sidebar.js
@@ -1,0 +1,17 @@
+export function createPlanetSidebar(planet) {
+  const container = document.createElement('div');
+  container.className = 'planet-sidebar';
+  const features = planet.features && planet.features.length ? planet.features.join(', ') : 'None';
+  container.innerHTML = `
+    <h2>${planet.type}</h2>
+    <ul>
+      <li><strong>Distance:</strong> ${planet.distance.toFixed(2)} AU</li>
+      <li><strong>Radius:</strong> ${planet.radius.toFixed(2)}</li>
+      <li><strong>Temperature:</strong> ${planet.temperature.toFixed(2)} K</li>
+      <li><strong>Habitable:</strong> ${planet.isHabitable ? 'Yes' : 'No'}</li>
+      <li><strong>Orbital Period:</strong> ${planet.orbitalPeriod.toFixed(2)} years</li>
+      <li><strong>Features:</strong> ${features}</li>
+    </ul>
+  `;
+  return container;
+}

--- a/client/js/galaxy.js
+++ b/client/js/galaxy.js
@@ -11,7 +11,7 @@ export function generateStarSystem() {
   return { stars: [star], planets };
 }
 
-export function generateGalaxy(size = 500, chance = 0.01) {
+export function generateGalaxy(size = 500, chance = 0.001) {
   const systems = [];
   for (let x = -size; x <= size; x++) {
     for (let y = -size; y <= size; y++) {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -1,8 +1,9 @@
 import { createHeader } from './components/header.js';
 import { createOverview } from './components/overview.js';
-import { createSidebar, setSidebarContent } from './components/sidebar.js';
+import { createSidebar, setSidebarContent, clearSidebar } from './components/sidebar.js';
 import { createStarSidebar } from './components/star-sidebar.js';
 import { createSystemOverview } from './components/system-overview.js';
+import { createPlanetSidebar } from './components/planet-sidebar.js';
 
 function init() {
   const app = document.getElementById('app');
@@ -15,10 +16,13 @@ function init() {
   let overview;
 
   function showGalaxy() {
-    const galaxyOverview = createOverview((system) => {
-      const starContent = createStarSidebar(system, showSystem);
-      setSidebarContent(sidebar, starContent);
-    });
+    const galaxyOverview = createOverview(
+      (system) => {
+        const starContent = createStarSidebar(system, showSystem);
+        setSidebarContent(sidebar, starContent);
+      },
+      showSystem
+    );
     if (overview) {
       main.replaceChild(galaxyOverview, overview);
     } else {
@@ -28,7 +32,17 @@ function init() {
   }
 
   function showSystem(system) {
-    const systemView = createSystemOverview(system, showGalaxy);
+    clearSidebar(sidebar);
+    const systemView = createSystemOverview(
+      system,
+      showGalaxy,
+      (planet) => {
+        const planetContent = createPlanetSidebar(planet);
+        setSidebarContent(sidebar, planetContent);
+      },
+      overview.width,
+      overview.height
+    );
     main.replaceChild(systemView, overview);
     overview = systemView;
   }

--- a/client/less/overview.less
+++ b/client/less/overview.less
@@ -11,3 +11,21 @@
   background-color: #000;
   display: block;
 }
+
+.system-overview {
+  flex: 1;
+  position: relative;
+
+  canvas {
+    width: 100%;
+    height: 100%;
+    background-color: #000;
+    display: block;
+  }
+
+  button {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+  }
+}

--- a/client/less/sidebar.less
+++ b/client/less/sidebar.less
@@ -9,7 +9,8 @@
   display: none;
 }
 
-.star-sidebar {
+.star-sidebar,
+.planet-sidebar {
   h2 {
     margin-top: 0;
   }


### PR DESCRIPTION
## Summary
- Reduce galaxy star system generation chance to 0.1%
- Add double-click to jump from galaxy to system view and handle planet hover/click with dedicated sidebar
- Ensure system overview canvas matches galaxy overview dimensions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890cb23f71c832a94dae5d07840ff44