### PR TITLE
feat: random planet orbits

### DIFF
--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -1,10 +1,4 @@
-const PLANET_COLORS = {
-  lava: '#ff4500',
-  rocky: '#b0b0b0',
-  terrestrial: '#2ecc71',
-  ice: '#87cefa',
-  'gas giant': '#f1c40f'
-};
+import { PLANET_COLORS } from '../data/planets.js';
 
 export function createSystemOverview(
   system,
@@ -30,10 +24,11 @@ export function createSystemOverview(
 
   const planetData = planets.map((planet) => {
     const orbitRadius = planet.distance * scale;
-    const px = cx + orbitRadius;
-    const py = cy;
-    const planetRadius = Math.max(2, planet.radius * 3);
-    return { planet, orbitRadius, px, py, planetRadius };
+    const angle = planet.angle || Math.random() * Math.PI * 2;
+    const px = cx + orbitRadius * Math.cos(angle);
+    const py = cy + orbitRadius * Math.sin(angle);
+    const planetRadius = planet.radius * 3;
+    return { planet, orbitRadius, angle, px, py, planetRadius };
   });
 
   let hoveredIndex = null;

--- a/client/js/data/planets.js
+++ b/client/js/data/planets.js
@@ -26,3 +26,16 @@ export const PLANET_TYPES = [
     radius: [3, 12]
   }
 ];
+
+export const PLANET_COLORS = {
+  lava: '#ff4500',
+  rocky: '#b0b0b0',
+  terrestrial: '#2ecc71',
+  ice: '#87cefa',
+  'gas giant': '#f1c40f'
+};
+
+export const PLANET_FEATURES = [
+  { name: 'base', chance: 0.1 },
+  { name: 'mine', chance: 0.1 }
+];

--- a/client/js/planet.js
+++ b/client/js/planet.js
@@ -1,4 +1,4 @@
-import { PLANET_TYPES } from './data/planets.js';
+import { PLANET_TYPES, PLANET_FEATURES } from './data/planets.js';
 
 export function generatePlanet(star, orbitIndex) {
   const distance = (orbitIndex + 1) * randomRange(0.3, 1.5); // in AU
@@ -12,9 +12,10 @@ export function generatePlanet(star, orbitIndex) {
     distance >= star.habitableZone[0] &&
     distance <= star.habitableZone[1];
   const orbitalPeriod = Math.sqrt(Math.pow(distance, 3) / star.mass); // in Earth years
-  const features = [];
-  if (Math.random() < 0.1) features.push('base');
-  if (Math.random() < 0.1) features.push('mine');
+  const features = PLANET_FEATURES.filter((f) => Math.random() < f.chance).map(
+    (f) => f.name
+  );
+  const angle = Math.random() * Math.PI * 2;
   return {
     type: rule.name,
     distance,
@@ -22,7 +23,8 @@ export function generatePlanet(star, orbitIndex) {
     temperature,
     isHabitable,
     orbitalPeriod,
-    features
+    features,
+    angle
   };
 }
 


### PR DESCRIPTION
## Summary
- move planet colors and features configuration to data files
- remove artificial cap on planet render size and track orbital angle
- scatter planets around orbits instead of lining them up

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890ce59377c832a9f1d9826feacda62