### PR TITLE
Refine system overview and enrich planet data

### DIFF
--- a/client/js/components/planet-sidebar.js
+++ b/client/js/components/planet-sidebar.js
@@ -2,6 +2,9 @@ export function createPlanetSidebar(planet) {
   const container = document.createElement('div');
   container.className = 'planet-sidebar';
   const features = planet.features && planet.features.length ? planet.features.join(', ') : 'None';
+  const resources = Object.entries(planet.resources || {})
+    .map(([name, amount]) => `${name}: ${amount}`)
+    .join(', ') || 'None';
   container.innerHTML = `
     <h2>${planet.type}</h2>
     <ul>
@@ -11,6 +14,7 @@ export function createPlanetSidebar(planet) {
       <li><strong>Habitable:</strong> ${planet.isHabitable ? 'Yes' : 'No'}</li>
       <li><strong>Orbital Period:</strong> ${planet.orbitalPeriod.toFixed(2)} years</li>
       <li><strong>Features:</strong> ${features}</li>
+      <li><strong>Resources:</strong> ${resources}</li>
     </ul>
   `;
   return container;

--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -22,12 +22,13 @@ export function createSystemOverview(
   const maxDistance = Math.max(...planets.map(p => p.distance), 1);
   const scale = (canvas.width / 2 - 20) / maxDistance;
 
+  const starRadius = star.size * 2;
   const planetData = planets.map((planet) => {
     const orbitRadius = planet.distance * scale;
-    const angle = planet.angle || Math.random() * Math.PI * 2;
+    const angle = Math.random() * Math.PI * 2;
     const px = cx + orbitRadius * Math.cos(angle);
     const py = cy + orbitRadius * Math.sin(angle);
-    const planetRadius = planet.radius * 3;
+    const planetRadius = Math.min(planet.radius * 3, starRadius - 1);
     return { planet, orbitRadius, angle, px, py, planetRadius };
   });
 
@@ -37,23 +38,11 @@ export function createSystemOverview(
     ctx.fillStyle = '#000';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-    planetData.forEach(({ planet, orbitRadius, px, py, planetRadius }, idx) => {
-      ctx.beginPath();
-      ctx.strokeStyle = '#444';
-      ctx.arc(cx, cy, orbitRadius, 0, Math.PI * 2);
-      ctx.stroke();
+    planetData.forEach(({ planet, px, py, planetRadius }) => {
       ctx.beginPath();
       ctx.fillStyle = PLANET_COLORS[planet.type] || '#fff';
       ctx.arc(px, py, planetRadius, 0, Math.PI * 2);
       ctx.fill();
-
-       if (idx === hoveredIndex) {
-        ctx.beginPath();
-        ctx.strokeStyle = 'rgba(255,255,255,0.8)';
-        ctx.lineWidth = 2;
-        ctx.arc(px, py, planetRadius + 3, 0, Math.PI * 2);
-        ctx.stroke();
-      }
 
       if (planet.features) {
         let iconX = px + planetRadius + 4;
@@ -74,10 +63,27 @@ export function createSystemOverview(
       }
     });
 
+    ctx.lineWidth = 1;
+    planetData.forEach(({ orbitRadius }) => {
+      ctx.beginPath();
+      ctx.strokeStyle = '#444';
+      ctx.arc(cx, cy, orbitRadius, 0, Math.PI * 2);
+      ctx.stroke();
+    });
+
     ctx.beginPath();
     ctx.fillStyle = star.color;
-    ctx.arc(cx, cy, star.size * 2, 0, Math.PI * 2);
+    ctx.arc(cx, cy, starRadius, 0, Math.PI * 2);
     ctx.fill();
+
+    if (hoveredIndex !== null) {
+      const { px, py, planetRadius } = planetData[hoveredIndex];
+      ctx.beginPath();
+      ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+      ctx.lineWidth = 2;
+      ctx.arc(px, py, planetRadius + 3, 0, Math.PI * 2);
+      ctx.stroke();
+    }
   }
 
   function getPlanetIndex(event) {

--- a/client/js/data/planets.js
+++ b/client/js/data/planets.js
@@ -39,3 +39,13 @@ export const PLANET_FEATURES = [
   { name: 'base', chance: 0.1 },
   { name: 'mine', chance: 0.1 }
 ];
+
+export const PLANET_RESOURCES = [
+  'iron',
+  'cobalt',
+  'uranium',
+  'carbon',
+  'silicon',
+  'nickel',
+  'water'
+];

--- a/client/js/planet.js
+++ b/client/js/planet.js
@@ -1,4 +1,4 @@
-import { PLANET_TYPES, PLANET_FEATURES } from './data/planets.js';
+import { PLANET_TYPES, PLANET_FEATURES, PLANET_RESOURCES } from './data/planets.js';
 
 export function generatePlanet(star, orbitIndex) {
   const distance = (orbitIndex + 1) * randomRange(0.3, 1.5); // in AU
@@ -16,6 +16,10 @@ export function generatePlanet(star, orbitIndex) {
     (f) => f.name
   );
   const angle = Math.random() * Math.PI * 2;
+  const resources = PLANET_RESOURCES.reduce((acc, res) => {
+    acc[res] = Math.floor(randomRange(0, 100));
+    return acc;
+  }, {});
   return {
     type: rule.name,
     distance,
@@ -24,7 +28,8 @@ export function generatePlanet(star, orbitIndex) {
     isHabitable,
     orbitalPeriod,
     features,
-    angle
+    angle,
+    resources
   };
 }
 


### PR DESCRIPTION
## Summary
- Randomize planet positions and cap their size below the star while rendering orbits over planets with uniform width.
- Add resource generation for each planet and surface these in the planet sidebar.

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6890d475d4ac832aab03688f6afe00c6