### PR TITLE
Add planetary atmospheres and moons with type-specific resources

### DIFF
--- a/client/js/components/planet-sidebar.js
+++ b/client/js/components/planet-sidebar.js
@@ -4,8 +4,23 @@ export function createPlanetSidebar(planet) {
   const features = planet.features && planet.features.length ? planet.features.join(', ') : 'None';
   const resourceEntries = Object.entries(planet.resources || {});
   const resourcesTable = resourceEntries.length
-    ? `<table class="resource-table"><thead><tr><th>Resource</th><th>Amount</th></tr></thead><tbody>${resourceEntries
+    ? `<table class="info-table"><thead><tr><th>Resource</th><th>Amount</th></tr></thead><tbody>${resourceEntries
         .map(([name, amount]) => `<tr><td>${name}</td><td>${amount}</td></tr>`)
+        .join('')}</tbody></table>`
+    : '<p>None</p>';
+  const atmosphereEntries = Object.entries(planet.atmosphere || {});
+  const atmosphereTable = atmosphereEntries.length
+    ? `<table class="info-table"><thead><tr><th>Gas</th><th>%</th></tr></thead><tbody>${atmosphereEntries
+        .map(([gas, percent]) => `<tr><td>${gas}</td><td>${percent}</td></tr>`)
+        .join('')}</tbody></table>`
+    : '<p>None</p>';
+  const moons = planet.moons || [];
+  const moonsTable = moons.length
+    ? `<table class="info-table"><thead><tr><th>Moon</th><th>Radius</th><th>Atmosphere</th></tr></thead><tbody>${moons
+        .map(
+          (m) =>
+            `<tr><td>${m.name}</td><td>${m.radius.toFixed(2)}</td><td>${m.atmosphere ? 'Yes' : 'No'}</td></tr>`
+        )
         .join('')}</tbody></table>`
     : '<p>None</p>';
 
@@ -19,8 +34,12 @@ export function createPlanetSidebar(planet) {
       <li><strong>Orbital Period:</strong> ${planet.orbitalPeriod.toFixed(2)} years</li>
       <li><strong>Features:</strong> ${features}</li>
     </ul>
+    <h3>Atmosphere</h3>
+    ${atmosphereTable}
     <h3>Resources</h3>
     ${resourcesTable}
+    <h3>Moons</h3>
+    ${moonsTable}
   `;
   return container;
 }

--- a/client/js/data/planets.js
+++ b/client/js/data/planets.js
@@ -40,12 +40,27 @@ export const PLANET_FEATURES = [
   { name: 'mine', chance: 0.1 }
 ];
 
-export const PLANET_RESOURCES = [
-  'iron',
-  'cobalt',
-  'uranium',
-  'carbon',
-  'silicon',
-  'nickel',
-  'water'
-];
+export const PLANET_RESOURCES = {
+  lava: ['sulfur', 'silicates', 'iron'],
+  rocky: ['iron', 'cobalt', 'uranium', 'carbon', 'silicon', 'nickel', 'water'],
+  terrestrial: [
+    'iron',
+    'cobalt',
+    'uranium',
+    'carbon',
+    'silicon',
+    'nickel',
+    'water',
+    'oxygen'
+  ],
+  ice: ['water', 'methane', 'ammonia', 'nitrogen'],
+  'gas giant': ['hydrogen', 'helium', 'methane', 'ammonia']
+};
+
+export const PLANET_ATMOSPHERES = {
+  lava: [],
+  rocky: ['carbon dioxide', 'nitrogen'],
+  terrestrial: ['nitrogen', 'oxygen', 'argon'],
+  ice: ['nitrogen', 'methane'],
+  'gas giant': ['hydrogen', 'helium', 'methane', 'ammonia']
+};

--- a/client/js/planet.js
+++ b/client/js/planet.js
@@ -1,4 +1,9 @@
-import { PLANET_TYPES, PLANET_FEATURES, PLANET_RESOURCES } from './data/planets.js';
+import {
+  PLANET_TYPES,
+  PLANET_FEATURES,
+  PLANET_RESOURCES,
+  PLANET_ATMOSPHERES
+} from './data/planets.js';
 
 export function generatePlanet(star, orbitIndex) {
   const distance = (orbitIndex + 1) * randomRange(0.3, 1.5); // in AU
@@ -16,10 +21,13 @@ export function generatePlanet(star, orbitIndex) {
     (f) => f.name
   );
   const angle = Math.random() * Math.PI * 2;
-  const resources = PLANET_RESOURCES.reduce((acc, res) => {
+  const resourceList = PLANET_RESOURCES[rule.name] || [];
+  const resources = resourceList.reduce((acc, res) => {
     acc[res] = Math.floor(randomRange(0, 100));
     return acc;
   }, {});
+  const atmosphere = generateAtmosphere(rule.name);
+  const moons = generateMoons(star, distance, radius);
   return {
     type: rule.name,
     distance,
@@ -29,10 +37,44 @@ export function generatePlanet(star, orbitIndex) {
     orbitalPeriod,
     features,
     angle,
-    resources
+    resources,
+    atmosphere,
+    moons
   };
 }
 
 function randomRange(min, max) {
   return Math.random() * (max - min) + min;
+}
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function generateAtmosphere(type) {
+  const gases = PLANET_ATMOSPHERES[type];
+  if (!gases || gases.length === 0) {
+    return null;
+  }
+  const values = gases.map(() => Math.random());
+  const sum = values.reduce((a, b) => a + b, 0);
+  const composition = {};
+  gases.forEach((g, i) => {
+    composition[g] = Math.round((values[i] / sum) * 100);
+  });
+  return composition;
+}
+
+function generateMoons(star, distance, planetRadius) {
+  const maxMoons = planetRadius > 3 ? 5 : planetRadius > 1 ? 3 : 1;
+  const count = randomInt(0, maxMoons);
+  const moons = [];
+  for (let i = 0; i < count; i++) {
+    const radius = randomRange(0.1, Math.min(planetRadius * 0.5, 1.5));
+    const typeRule =
+      PLANET_TYPES.find((r) => distance <= r.maxDistance(star)) || PLANET_TYPES[0];
+    const atmosphere = radius > 0.5 ? generateAtmosphere(typeRule.name) : null;
+    moons.push({ name: `Moon ${i + 1}`, radius, atmosphere });
+  }
+  return moons;
 }

--- a/client/less/sidebar.less
+++ b/client/less/sidebar.less
@@ -24,7 +24,7 @@
   }
 }
 
-.resource-table {
+.info-table {
   width: 100%;
   border-collapse: collapse;
   margin-top: 0.5rem;


### PR DESCRIPTION
## Summary
- Give each planet type its own resource set and atmospheric gases
- Generate atmospheres and moons for planets, with moons gaining air if big enough
- Display atmosphere details and moons in planet sidebar; style tables consistently

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e356baac832a8c14a28be8a1dcd4