### PR TITLE
Treat moons as scaled-down rocky planets

### DIFF
--- a/client/js/components/planet-sidebar.js
+++ b/client/js/components/planet-sidebar.js
@@ -16,10 +16,10 @@ export function createPlanetSidebar(planet) {
     : '<p>None</p>';
   const moons = planet.moons || [];
   const moonsTable = moons.length
-    ? `<table class="info-table"><thead><tr><th>Moon</th><th>Radius</th><th>Atmosphere</th></tr></thead><tbody>${moons
+    ? `<table class="info-table"><thead><tr><th>Moon</th><th>Type</th><th>Radius</th><th>Atmosphere</th></tr></thead><tbody>${moons
         .map(
-          (m) =>
-            `<tr><td>${m.name}</td><td>${m.radius.toFixed(2)}</td><td>${m.atmosphere ? 'Yes' : 'No'}</td></tr>`
+          (m, i) =>
+            `<tr><td>${m.name || `Moon ${i + 1}`}</td><td>${m.type}</td><td>${m.radius.toFixed(2)}</td><td>${m.atmosphere ? 'Yes' : 'No'}</td></tr>`
         )
         .join('')}</tbody></table>`
     : '<p>None</p>';


### PR DESCRIPTION
## Summary
- Ensure moons are no larger than one tenth of their host planet and always rocky
- Scale moon resources by size and return full planet objects
- Show moon type in planet sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e6d9f448832aa642101fe9a6d8b8