### PR TITLE
Unify planet and moon generation with orbital eccentricity

### DIFF
--- a/client/js/components/planet-sidebar.js
+++ b/client/js/components/planet-sidebar.js
@@ -19,7 +19,7 @@ export function createPlanetSidebar(planet) {
     ? `<table class="info-table"><thead><tr><th>Moon</th><th>Type</th><th>Radius</th><th>Atmosphere</th></tr></thead><tbody>${moons
         .map(
           (m, i) =>
-            `<tr><td>${m.name || `Moon ${i + 1}`}</td><td>${m.type}</td><td>${m.radius.toFixed(2)}</td><td>${m.atmosphere ? 'Yes' : 'No'}</td></tr>`
+            `<tr><td>${m.name || `Moon ${i + 1}`}</td><td>${m.type}</td><td>${m.radius.toFixed(2)}</td><td>${m.atmosphere ? formatAtmosphere(m.atmosphere) : 'None'}</td></tr>`
         )
         .join('')}</tbody></table>`
     : '<p>None</p>';
@@ -32,6 +32,7 @@ export function createPlanetSidebar(planet) {
       <li><strong>Temperature:</strong> ${planet.temperature.toFixed(2)} K</li>
       <li><strong>Habitable:</strong> ${planet.isHabitable ? 'Yes' : 'No'}</li>
       <li><strong>Orbital Period:</strong> ${planet.orbitalPeriod.toFixed(2)} years</li>
+      <li><strong>Eccentricity:</strong> ${planet.eccentricity.toFixed(2)}</li>
       <li><strong>Features:</strong> ${features}</li>
     </ul>
     <h3>Atmosphere</h3>
@@ -42,4 +43,10 @@ export function createPlanetSidebar(planet) {
     ${moonsTable}
   `;
   return container;
+}
+
+function formatAtmosphere(atmo) {
+  return Object.entries(atmo)
+    .map(([gas, percent]) => `${gas} (${percent}%)`)
+    .join(', ');
 }

--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -24,12 +24,20 @@ export function createSystemOverview(
 
   const starRadius = star.size * 2;
   const planetData = planets.map((planet) => {
-    const orbitRadius = planet.distance * scale;
-    const angle = Math.random() * Math.PI * 2;
-    const px = cx + orbitRadius * Math.cos(angle);
-    const py = cy + orbitRadius * Math.sin(angle);
+    const orbitA = planet.distance * scale;
+    const e = planet.eccentricity || 0;
+    const orbitB = orbitA * Math.sqrt(1 - e * e);
+    const rotation = planet.orbitRotation || 0;
+    const theta = planet.angle;
+    const r = (orbitA * (1 - e * e)) / (1 + e * Math.cos(theta));
+    const x = r * Math.cos(theta);
+    const y = r * Math.sin(theta);
+    const xRot = x * Math.cos(rotation) - y * Math.sin(rotation);
+    const yRot = x * Math.sin(rotation) + y * Math.cos(rotation);
+    const px = cx + xRot;
+    const py = cy + yRot;
     const planetRadius = Math.min(planet.radius * 3, starRadius - 1);
-    return { planet, orbitRadius, angle, px, py, planetRadius };
+    return { planet, orbitA, orbitB, e, rotation, theta, px, py, planetRadius };
   });
 
   let hoveredIndex = null;
@@ -40,10 +48,13 @@ export function createSystemOverview(
 
     // Draw orbits first so they appear beneath planets
     ctx.lineWidth = 1;
-    planetData.forEach(({ orbitRadius }) => {
+    planetData.forEach(({ orbitA, orbitB, e, rotation }) => {
       ctx.beginPath();
       ctx.strokeStyle = '#444';
-      ctx.arc(cx, cy, orbitRadius, 0, Math.PI * 2);
+      const centerX = cx + orbitA * e * Math.cos(rotation);
+      const centerY = cy + orbitA * e * Math.sin(rotation);
+      // Draw orbit as an ellipse with the star at one focus
+      ctx.ellipse(centerX, centerY, orbitA, orbitB, rotation, 0, Math.PI * 2);
       ctx.stroke();
     });
 

--- a/client/js/galaxy.js
+++ b/client/js/galaxy.js
@@ -1,13 +1,13 @@
 import { generateStar } from './star.js';
-import { generatePlanet } from './planet.js';
+import { generateBody } from './planet.js';
 
 export function generateStarSystem() {
   const star = generateStar();
   const planetCount = randomInt(0, 10);
-  const planets = Array.from(
-    { length: planetCount },
-    (_, i) => generatePlanet(star, i)
-  );
+  const planets = [];
+  for (let i = 0; i < planetCount; i++) {
+    planets.push(generateBody(star, i, null, planets));
+  }
   return { stars: [star], planets };
 }
 


### PR DESCRIPTION
## Summary
- Treat planets and moons as the same kind of body with size limits and atmosphere data
- Bias body types by orbital distance and gas giant neighbors
- Render elliptical orbits using eccentricity

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check client/js/planet.js`
- `node --check client/js/galaxy.js`
- `node --check client/js/components/planet-sidebar.js`
- `node --check client/js/components/system-overview.js`


------
https://chatgpt.com/codex/tasks/task_e_6890f4aa7fec832aa8809c7b53a0ba0a