### PR TITLE
Fix orbit alignment and moon variety

### DIFF
--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -51,8 +51,8 @@ export function createSystemOverview(
     planetData.forEach(({ orbitA, orbitB, e, rotation }) => {
       ctx.beginPath();
       ctx.strokeStyle = '#444';
-      const centerX = cx + orbitA * e * Math.cos(rotation);
-      const centerY = cy + orbitA * e * Math.sin(rotation);
+      const centerX = cx - orbitA * e * Math.cos(rotation);
+      const centerY = cy - orbitA * e * Math.sin(rotation);
       // Draw orbit as an ellipse with the star at one focus
       ctx.ellipse(centerX, centerY, orbitA, orbitB, rotation, 0, Math.PI * 2);
       ctx.stroke();

--- a/client/js/planet.js
+++ b/client/js/planet.js
@@ -26,10 +26,17 @@ export function generateBody(star, orbitIndex, parent = null, siblings = []) {
     radius = Math.min(radius, parent.radius * 0.1);
   }
 
+  // Determine final type based on resulting radius. Small bodies below 0.3
+  // Earth radii have no atmosphere and can only be rocky or lava worlds.
+  let type = rule.name;
+  if (radius < 0.3) {
+    type = Math.random() < 0.5 ? 'rocky' : 'lava';
+  }
+
   const temperature =
     278 * Math.pow(star.luminosity, 0.25) / Math.sqrt(distance);
   const isHabitable =
-    !!rule.habitable &&
+    type === 'terrestrial' &&
     distance >= star.habitableZone[0] &&
     distance <= star.habitableZone[1];
   const orbitalPeriod = Math.sqrt(Math.pow(distance, 3) / star.mass); // in Earth years
@@ -39,15 +46,15 @@ export function generateBody(star, orbitIndex, parent = null, siblings = []) {
   const angle = Math.random() * Math.PI * 2;
   const eccentricity = Math.random() ** 2 * 0.6;
   const orbitRotation = Math.random() * Math.PI * 2;
-  const resourceList = PLANET_RESOURCES[rule.name] || [];
+  const resourceList = PLANET_RESOURCES[type] || [];
   const resources = resourceList.reduce((acc, res) => {
     acc[res] = Math.floor(randomRange(0, 100));
     return acc;
   }, {});
-  const atmosphere = generateAtmosphere(rule.name);
+  const atmosphere = radius < 0.3 ? null : generateAtmosphere(type);
   const body = {
     name: parent ? `Moon ${orbitIndex + 1}` : `Planet ${orbitIndex + 1}`,
-    type: rule.name,
+    type,
     distance,
     radius,
     temperature,


### PR DESCRIPTION
## Summary
- Correct ellipse center so planets align with orbits
- Assign planet type based on final radius and remove atmospheres from tiny bodies

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890f9cff55c832a8a4dee9660a7f4b3