### PR TITLE
Improve overview controls and planet scaling

### DIFF
--- a/client/js/components/overview.js
+++ b/client/js/components/overview.js
@@ -8,8 +8,10 @@ export function createOverview({ update, draw } = {}) {
 
   const zoomInBtn = document.createElement('button');
   zoomInBtn.textContent = '+';
+  zoomInBtn.className = 'zoom-btn zoom-in';
   const zoomOutBtn = document.createElement('button');
   zoomOutBtn.textContent = '-';
+  zoomOutBtn.className = 'zoom-btn zoom-out';
   container.append(zoomInBtn, zoomOutBtn);
 
   let zoom = 1;

--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -10,11 +10,12 @@ export function createSystemOverview(
 ) {
   const star = system.stars[0];
   const planets = system.planets;
-  const BODY_SCALE = 12;
+  const STAR_SCALE = 12;
+  const PLANET_SCALE = 6;
 
-  const baseStarRadius = star.size * 2 * BODY_SCALE;
+  const baseStarRadius = star.size * 2 * STAR_SCALE;
   const baseMaxPlanetRadius = Math.max(
-    ...planets.map((p) => Math.min(p.radius * 2 * BODY_SCALE, baseStarRadius - 1)),
+    ...planets.map((p) => Math.min(p.radius * 2 * PLANET_SCALE, baseStarRadius - 1)),
     0
   );
 
@@ -59,7 +60,7 @@ export function createSystemOverview(
       const py = cy + yRot;
       const planetRadius = Math.max(
         0,
-        Math.min(planet.radius * 2 * BODY_SCALE * zoom, starRadius - 1)
+        Math.min(planet.radius * 2 * PLANET_SCALE * zoom, starRadius - 1)
       );
       return { planet, orbitA, orbitB, e, rotation, theta, px, py, planetRadius };
     });
@@ -165,6 +166,7 @@ export function createSystemOverview(
 
   const backBtn = document.createElement('button');
   backBtn.textContent = 'Back';
+  backBtn.className = 'back-btn';
   backBtn.addEventListener('click', () => {
     overview.destroy();
     if (typeof onBack === 'function') {

--- a/client/less/overview.less
+++ b/client/less/overview.less
@@ -17,9 +17,25 @@
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
   }
 
-  button {
+  .back-btn {
     position: absolute;
     top: 8px;
     left: 8px;
+  }
+
+  .zoom-btn {
+    position: absolute;
+    right: 8px;
+    width: 40px;
+    height: 40px;
+    font-size: 24px;
+  }
+
+  .zoom-in {
+    top: 8px;
+  }
+
+  .zoom-out {
+    top: 56px;
   }
 }


### PR DESCRIPTION
## Summary
- style overview zoom buttons with dedicated classes for improved visibility and spacing
- position back button separately from zoom controls and halve planet render scale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891de804990832aa5708f26c41e5d89