### PR TITLE
Limit planet size and restore star selection

### DIFF
--- a/client/js/components/galaxy-overview.js
+++ b/client/js/components/galaxy-overview.js
@@ -1,9 +1,12 @@
-import { generateGalaxy } from '../galaxy.js';
 import { createOverview } from './overview.js';
 
-export function createGalaxyOverview(onSelect, onOpenSystem) {
+export function createGalaxyOverview(
+  galaxy,
+  onSelect,
+  onOpenSystem,
+  selectedSystem = null
+) {
   const STAR_RADIUS = 8;
-  const galaxy = generateGalaxy();
   const size = galaxy.size;
 
   const systems = galaxy.systems.map(({ x, y, system }) => ({
@@ -15,6 +18,8 @@ export function createGalaxyOverview(onSelect, onOpenSystem) {
 
   let starPositions = [];
   let hoveredIndex = null;
+  let selectedIndex =
+    selectedSystem ? systems.findIndex((s) => s.system === selectedSystem) : null;
   let canvas;
   let ctx;
 
@@ -40,7 +45,7 @@ export function createGalaxyOverview(onSelect, onOpenSystem) {
       ctx.arc(cx, cy, STAR_RADIUS, 0, Math.PI * 2);
       ctx.fill();
 
-      if (idx === hoveredIndex) {
+      if (idx === hoveredIndex || idx === selectedIndex) {
         ctx.beginPath();
         ctx.strokeStyle = 'rgba(255,255,255,0.8)';
         ctx.lineWidth = 2;
@@ -86,8 +91,12 @@ export function createGalaxyOverview(onSelect, onOpenSystem) {
     clearTimeout(clickTimeout);
     clickTimeout = setTimeout(() => {
       const idx = getStarIndex(e);
-      if (idx !== -1 && typeof onSelect === 'function') {
-        onSelect(systems[idx].system);
+      if (idx !== -1) {
+        selectedIndex = idx;
+        if (typeof onSelect === 'function') {
+          onSelect(systems[idx].system);
+        }
+        draw();
       }
     }, 200);
   });
@@ -95,8 +104,12 @@ export function createGalaxyOverview(onSelect, onOpenSystem) {
   canvas.addEventListener('dblclick', (e) => {
     clearTimeout(clickTimeout);
     const idx = getStarIndex(e);
-    if (idx !== -1 && typeof onOpenSystem === 'function') {
-      onOpenSystem(systems[idx].system);
+    if (idx !== -1) {
+      selectedIndex = idx;
+      draw();
+      if (typeof onOpenSystem === 'function') {
+        onOpenSystem(systems[idx].system);
+      }
     }
   });
 

--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -15,7 +15,7 @@ export function createSystemOverview(
 
   const baseStarRadius = star.size * 2 * STAR_SCALE;
   const baseMaxPlanetRadius = Math.max(
-    ...planets.map((p) => Math.min(p.radius * 2 * PLANET_SCALE, baseStarRadius - 1)),
+    ...planets.map((p) => Math.min(p.radius * 2 * PLANET_SCALE, baseStarRadius / 4)),
     0
   );
 
@@ -60,7 +60,10 @@ export function createSystemOverview(
       const py = cy + yRot;
       const planetRadius = Math.max(
         0,
-        Math.min(planet.radius * 2 * PLANET_SCALE * zoom, starRadius - 1)
+        Math.min(
+          planet.radius * 2 * PLANET_SCALE * zoom,
+          starRadius / 4
+        )
       );
       return { planet, orbitA, orbitB, e, rotation, theta, px, py, planetRadius };
     });

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -4,6 +4,7 @@ import { createSidebar, setSidebarContent, clearSidebar } from './components/sid
 import { createStarSidebar } from './components/star-sidebar.js';
 import { createSystemOverview } from './components/system-overview.js';
 import { createPlanetSidebar } from './components/planet-sidebar.js';
+import { generateGalaxy } from './galaxy.js';
 
 function init() {
   const app = document.getElementById('app');
@@ -14,14 +15,17 @@ function init() {
 
   const sidebar = createSidebar();
   let overview;
+  const galaxy = generateGalaxy();
 
-  function showGalaxy() {
+  function showGalaxy(selectedSystem = null) {
     const galaxyOverview = createGalaxyOverview(
+      galaxy,
       (system) => {
         const starContent = createStarSidebar(system, showSystem);
         setSidebarContent(sidebar, starContent);
       },
-      showSystem
+      showSystem,
+      selectedSystem
     );
     if (overview) {
       main.replaceChild(galaxyOverview, overview);
@@ -29,13 +33,20 @@ function init() {
       main.append(galaxyOverview);
     }
     overview = galaxyOverview;
+
+    if (selectedSystem) {
+      const starContent = createStarSidebar(selectedSystem, showSystem);
+      setSidebarContent(sidebar, starContent);
+    } else {
+      clearSidebar(sidebar);
+    }
   }
 
   function showSystem(system) {
     clearSidebar(sidebar);
     const systemView = createSystemOverview(
       system,
-      showGalaxy,
+      () => showGalaxy(system),
       (planet) => {
         const planetContent = createPlanetSidebar(planet);
         setSidebarContent(sidebar, planetContent);


### PR DESCRIPTION
## Summary
- cap rendered planet radii to one quarter of the star's size
- keep galaxy overview star selection and sidebar when returning from system view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891e29757fc832a9a2df15d7836bff8