### PR TITLE
feat: add planet overview with orbital objects

### DIFF
--- a/client/js/components/base-sidebar.js
+++ b/client/js/components/base-sidebar.js
@@ -1,0 +1,14 @@
+export function createBaseSidebar(base) {
+  const container = document.createElement('div');
+  container.className = 'base-sidebar';
+  const orbit = base.orbitDistance || 0;
+  container.innerHTML = `
+    <h2>${base.name}</h2>
+    <ul>
+      <li><strong>Orbit Distance:</strong> ${orbit.toFixed(3)} AU</li>
+      <li><strong>Radius:</strong> ${base.radius.toFixed(2)}</li>
+      <li><strong>Population:</strong> ${base.population}</li>
+    </ul>
+  `;
+  return container;
+}

--- a/client/js/components/planet-overview.js
+++ b/client/js/components/planet-overview.js
@@ -1,0 +1,190 @@
+import { PLANET_COLORS } from '../data/planets.js';
+import { createOverview } from './overview.js';
+
+export function createPlanetOverview(
+  planet,
+  onBack,
+  onSelectObject,
+  width = 400,
+  height = 400
+) {
+  const objects = planet.moons || [];
+  const PLANET_SCALE = 20;
+  const OBJECT_SCALE = 6;
+
+  let planetRadius = planet.radius * PLANET_SCALE;
+  let objectData = [];
+  let hoveredIndex = null;
+  let canvas;
+  let ctx;
+
+  function updateLayout(zoom) {
+    const cx = canvas.width / 2;
+    const cy = canvas.height / 2;
+    const maxOrbit = Math.max(
+      ...objects.map((o) => (o.orbitDistance || o.distance - planet.distance) * (1 + (o.eccentricity || 0))),
+      1
+    );
+    const scaleBase = Math.max(
+      (Math.min(canvas.width, canvas.height) / 2 - planetRadius - 20) / maxOrbit,
+      0.1
+    );
+    const scale = scaleBase * zoom;
+    planetRadius = Math.max(planet.radius * PLANET_SCALE * zoom, 0);
+    objectData = objects.map((obj) => {
+      const dist = obj.orbitDistance || obj.distance - planet.distance;
+      const orbitA = Math.max(dist * scale, 0);
+      const e = obj.eccentricity || 0;
+      const orbitB = Math.max(orbitA * Math.sqrt(Math.max(0, 1 - e * e)), 0);
+      const rotation = obj.orbitRotation || 0;
+      const theta = obj.angle || 0;
+      const r = (orbitA * (1 - e * e)) / (1 + e * Math.cos(theta));
+      const x = r * Math.cos(theta);
+      const y = r * Math.sin(theta);
+      const xRot = x * Math.cos(rotation) - y * Math.sin(rotation);
+      const yRot = x * Math.sin(rotation) + y * Math.cos(rotation);
+      const px = cx + xRot;
+      const py = cy + yRot;
+      const objRadius = Math.max(
+        0,
+        Math.min(obj.radius * OBJECT_SCALE * zoom, planetRadius / 4)
+      );
+      return { obj, orbitA, orbitB, e, rotation, theta, px, py, objRadius };
+    });
+  }
+
+  function draw() {
+    const cx = canvas.width / 2;
+    const cy = canvas.height / 2;
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.lineWidth = 1;
+    objectData.forEach(({ orbitA, orbitB, e, rotation }) => {
+      if (orbitA > 0 && orbitB > 0) {
+        ctx.beginPath();
+        ctx.strokeStyle = '#444';
+        const centerX = cx - orbitA * e * Math.cos(rotation);
+        const centerY = cy - orbitA * e * Math.sin(rotation);
+        ctx.ellipse(centerX, centerY, orbitA, orbitB, rotation, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    });
+
+    objectData.forEach(({ obj, px, py, objRadius }) => {
+      ctx.beginPath();
+      if (obj.type === 'base') {
+        ctx.fillStyle = '#fff';
+        ctx.fillRect(px - objRadius, py - objRadius, objRadius * 2, objRadius * 2);
+      } else {
+        ctx.fillStyle = PLANET_COLORS[obj.type] || '#fff';
+        ctx.arc(px, py, objRadius, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    });
+
+    ctx.beginPath();
+    ctx.fillStyle = PLANET_COLORS[planet.type] || '#fff';
+    ctx.arc(cx, cy, planetRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    if (planet.features) {
+      let iconX = cx + planetRadius + 4;
+      const iconY = cy;
+      planet.features
+        .filter((f) => f !== 'base')
+        .forEach((f) => {
+          ctx.fillStyle = '#fff';
+          if (f === 'mine') {
+            ctx.beginPath();
+            ctx.moveTo(iconX, iconY - 3);
+            ctx.lineTo(iconX + 4, iconY - 3);
+            ctx.lineTo(iconX + 2, iconY + 1);
+            ctx.fill();
+          }
+          iconX += 6;
+        });
+    }
+
+    if (hoveredIndex !== null) {
+      const { px, py, objRadius, obj } = objectData[hoveredIndex];
+      ctx.beginPath();
+      ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+      ctx.lineWidth = 2;
+      if (obj.type === 'base') {
+        ctx.strokeRect(px - objRadius - 2, py - objRadius - 2, objRadius * 2 + 4, objRadius * 2 + 4);
+      } else {
+        ctx.arc(px, py, objRadius + 3, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    }
+  }
+
+  const overview = createOverview({
+    update: updateLayout,
+    draw,
+  });
+
+  canvas = overview.canvas;
+  ctx = overview.ctx;
+  overview.container.style.width = `${width}px`;
+  overview.container.style.height = `${height}px`;
+
+  function getObjectIndex(event) {
+    const rect = canvas.getBoundingClientRect();
+    const scale = canvas.width / rect.width;
+    const x = (event.clientX - rect.left) * scale;
+    const y = (event.clientY - rect.top) * scale;
+    return objectData.findIndex(({ px, py, objRadius, obj }) => {
+      const dx = px - x;
+      const dy = py - y;
+      if (obj.type === 'base') {
+        return Math.abs(dx) <= objRadius && Math.abs(dy) <= objRadius;
+      }
+      return Math.sqrt(dx * dx + dy * dy) <= objRadius;
+    });
+  }
+
+  canvas.addEventListener('mousemove', (e) => {
+    const idx = getObjectIndex(e);
+    hoveredIndex = idx === -1 ? null : idx;
+    draw();
+  });
+
+  canvas.addEventListener('mouseleave', () => {
+    hoveredIndex = null;
+    draw();
+  });
+
+  canvas.addEventListener('click', (e) => {
+    const idx = getObjectIndex(e);
+    if (idx !== -1 && typeof onSelectObject === 'function') {
+      onSelectObject(objectData[idx].obj);
+      return;
+    }
+    const rect = canvas.getBoundingClientRect();
+    const scale = canvas.width / rect.width;
+    const x = (e.clientX - rect.left) * scale;
+    const y = (e.clientY - rect.top) * scale;
+    const dx = canvas.width / 2 - x;
+    const dy = canvas.height / 2 - y;
+    if (Math.sqrt(dx * dx + dy * dy) <= planetRadius) {
+      if (typeof onSelectObject === 'function') {
+        onSelectObject(planet);
+      }
+    }
+  });
+
+  const backBtn = document.createElement('button');
+  backBtn.textContent = 'Back';
+  backBtn.className = 'back-btn';
+  backBtn.addEventListener('click', () => {
+    overview.destroy();
+    if (typeof onBack === 'function') {
+      onBack();
+    }
+  });
+  overview.container.appendChild(backBtn);
+
+  return overview.container;
+}

--- a/client/js/components/planet-sidebar.js
+++ b/client/js/components/planet-sidebar.js
@@ -1,7 +1,10 @@
 export function createPlanetSidebar(planet) {
   const container = document.createElement('div');
   container.className = 'planet-sidebar';
-  const features = planet.features && planet.features.length ? planet.features.join(', ') : 'None';
+  const surfaceObjects = (planet.features || []).filter((f) => f !== 'base');
+  const surfaceContent = surfaceObjects.length
+    ? `<ul>${surfaceObjects.map((s) => `<li>${s}</li>`).join('')}</ul>`
+    : '<p>None</p>';
   const resourceEntries = Object.entries(planet.resources || {});
   const resourcesTable = resourceEntries.length
     ? `<table class="info-table"><thead><tr><th>Resource</th><th>Amount</th></tr></thead><tbody>${resourceEntries
@@ -16,10 +19,10 @@ export function createPlanetSidebar(planet) {
     : '<p>None</p>';
   const moons = planet.moons || [];
   const moonsTable = moons.length
-    ? `<table class="info-table"><thead><tr><th>Moon</th><th>Type</th><th>Radius</th><th>Atmosphere</th></tr></thead><tbody>${moons
+    ? `<table class="info-table"><thead><tr><th>Name</th><th>Type</th><th>Radius</th><th>Atmosphere</th></tr></thead><tbody>${moons
         .map(
           (m, i) =>
-            `<tr><td>${m.name || `Moon ${i + 1}`}</td><td>${m.type}</td><td>${m.radius.toFixed(2)}</td><td>${m.atmosphere ? formatAtmosphere(m.atmosphere) : 'None'}</td></tr>`
+            `<tr><td>${m.name || `Object ${i + 1}`}</td><td>${m.type}</td><td>${m.radius.toFixed(2)}</td><td>${m.atmosphere ? formatAtmosphere(m.atmosphere) : 'None'}</td></tr>`
         )
         .join('')}</tbody></table>`
     : '<p>None</p>';
@@ -33,13 +36,14 @@ export function createPlanetSidebar(planet) {
       <li><strong>Habitable:</strong> ${planet.isHabitable ? 'Yes' : 'No'}</li>
       <li><strong>Orbital Period:</strong> ${planet.orbitalPeriod.toFixed(2)} years</li>
       <li><strong>Eccentricity:</strong> ${planet.eccentricity.toFixed(2)}</li>
-      <li><strong>Features:</strong> ${features}</li>
     </ul>
+    <h3>Surface Objects</h3>
+    ${surfaceContent}
     <h3>Atmosphere</h3>
     ${atmosphereTable}
     <h3>Resources</h3>
     ${resourcesTable}
-    <h3>Moons</h3>
+    <h3>Orbiting Objects</h3>
     ${moonsTable}
   `;
   return container;

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -4,6 +4,8 @@ import { createSidebar, setSidebarContent, clearSidebar } from './components/sid
 import { createStarSidebar } from './components/star-sidebar.js';
 import { createSystemOverview } from './components/system-overview.js';
 import { createPlanetSidebar } from './components/planet-sidebar.js';
+import { createPlanetOverview } from './components/planet-overview.js';
+import { createBaseSidebar } from './components/base-sidebar.js';
 import { generateGalaxy } from './galaxy.js';
 
 function init() {
@@ -42,20 +44,44 @@ function init() {
     }
   }
 
-  function showSystem(system) {
-    clearSidebar(sidebar);
+  function showSystem(system, selectedPlanet = null) {
     const systemView = createSystemOverview(
       system,
       () => showGalaxy(system),
-      (planet) => {
-        const planetContent = createPlanetSidebar(planet);
-        setSidebarContent(sidebar, planetContent);
-      },
+      (planet) => showPlanet(system, planet),
       overview.offsetWidth,
       overview.offsetHeight
     );
     main.replaceChild(systemView, overview);
     overview = systemView;
+    if (selectedPlanet) {
+      const planetContent = createPlanetSidebar(selectedPlanet);
+      setSidebarContent(sidebar, planetContent);
+    } else {
+      clearSidebar(sidebar);
+    }
+  }
+
+  function showPlanet(system, planet) {
+    const planetView = createPlanetOverview(
+      planet,
+      () => showSystem(system, planet),
+      (obj) => {
+        let content;
+        if (obj.type === 'base') {
+          content = createBaseSidebar(obj);
+        } else {
+          content = createPlanetSidebar(obj);
+        }
+        setSidebarContent(sidebar, content);
+      },
+      overview.offsetWidth,
+      overview.offsetHeight
+    );
+    main.replaceChild(planetView, overview);
+    overview = planetView;
+    const planetContent = createPlanetSidebar(planet);
+    setSidebarContent(sidebar, planetContent);
   }
 
   showGalaxy();

--- a/client/js/stellar-object.js
+++ b/client/js/stellar-object.js
@@ -37,6 +37,33 @@ export function generateStellarObject(
     return obj;
   }
 
+  if (kind === 'base') {
+    const orbitDistance = (orbitIndex + 1) * randomRange(0.001, 0.01);
+    const distance = parent.distance + orbitDistance;
+    const angle = Math.random() * Math.PI * 2;
+    const eccentricity = Math.random() * 0.01;
+    const orbitRotation = Math.random() * Math.PI * 2;
+    const body = {
+      name: `Base ${orbitIndex + 1}`,
+      type: 'base',
+      distance,
+      orbitDistance,
+      radius: 0.05,
+      temperature: parent.temperature,
+      isHabitable: true,
+      orbitalPeriod: Math.sqrt(Math.pow(distance, 3) / star.mass),
+      features: [],
+      angle,
+      eccentricity,
+      orbitRotation,
+      resources: {},
+      atmosphere: null,
+      moons: [],
+      population: Math.floor(randomRange(100, 1000))
+    };
+    return body;
+  }
+
   // planet or moon generation
   const baseDistance = parent ? parent.distance : 0;
   const step = parent
@@ -126,6 +153,9 @@ function generateChildren(star, body) {
   const moons = [];
   for (let i = 0; i < count; i++) {
     moons.push(generateStellarObject('moon', star, i, body, moons));
+  }
+  if (body.features?.includes('base')) {
+    moons.push(generateStellarObject('base', star, moons.length, body, moons));
   }
   return moons;
 }

--- a/test/stellar-object.test.js
+++ b/test/stellar-object.test.js
@@ -24,6 +24,11 @@ function expectedMaxMoons(radius) {
 }
 
 function validateBody(body, star) {
+  if (body.type === 'base') {
+    assert.ok(body.distance > 0);
+    assert.ok(typeof body.radius === 'number');
+    return;
+  }
   assert.ok(planetTypeNames.includes(body.type));
   const rule = PLANET_TYPES.find((t) => t.name === body.type);
   if (body.name.startsWith('Planet')) {
@@ -57,8 +62,9 @@ function validateBody(body, star) {
     assert.equal(body.isHabitable, false);
   }
 
+  const naturalMoons = body.moons.filter((m) => m.type !== 'base');
   const maxMoons = expectedMaxMoons(body.radius);
-  assert.ok(body.moons.length <= maxMoons);
+  assert.ok(naturalMoons.length <= maxMoons);
   body.moons.forEach((m) => validateBody(m, star));
 }
 
@@ -83,7 +89,9 @@ test('planet with five moons has unique moon radii', () => {
   let targetPlanet = null;
   for (let i = 0; i < 100 && !targetPlanet; i++) {
     const star = generateStellarObject('star');
-    targetPlanet = star.planets.find((p) => p.moons.length === 5);
+    targetPlanet = star.planets.find(
+      (p) => p.moons.filter((m) => m.type !== 'base').length === 5
+    );
   }
   assert.ok(targetPlanet, 'Failed to generate planet with five moons');
   const radii = targetPlanet.moons.map((m) => m.radius);


### PR DESCRIPTION
## Summary
- render a planet-specific overview showing moons and orbital bases with clickable orbits
- list planetary surface objects separately from orbiting bodies
- generate bases as dedicated stellar objects and handle them in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891e828c144832a8cb3ab4371e9258c