### PR TITLE
refactor: separate star generation

### DIFF
--- a/client/js/star.js
+++ b/client/js/star.js
@@ -1,0 +1,29 @@
+import { STAR_TYPES, STAR_CLASS_COLORS } from './data/stars.js';
+import { generateStellarObject, randomInt, randomRange, StellarObject } from './stellar-object.js';
+
+export class Star extends StellarObject {
+  constructor() {
+    const type = STAR_TYPES[randomInt(0, STAR_TYPES.length - 1)];
+    super({
+      class: type.class,
+      name: type.name,
+      color: STAR_CLASS_COLORS[type.class],
+      size: type.size,
+      mass: randomRange(type.mass[0], type.mass[1]),
+      luminosity: randomRange(type.luminosity[0], type.luminosity[1]),
+      radius: randomRange(type.radius[0], type.radius[1]),
+      habitableZone: type.habitableZone
+    });
+    this.planets = [];
+    const planetCount = randomInt(0, 10);
+    for (let i = 0; i < planetCount; i++) {
+      this.planets.push(
+        generateStellarObject('planet', this, i, null, this.planets)
+      );
+    }
+  }
+}
+
+export function generateStar() {
+  return new Star();
+}

--- a/client/js/stellar-object.js
+++ b/client/js/stellar-object.js
@@ -1,4 +1,3 @@
-import { STAR_TYPES, STAR_CLASS_COLORS } from './data/stars.js';
 import {
   PLANET_TYPES,
   PLANET_FEATURES,
@@ -7,7 +6,13 @@ import {
   MOON_RULES
 } from './data/planets.js';
 
-// Generic generator for stars, planets and moons including their orbiting bodies
+export class StellarObject {
+  constructor(props) {
+    Object.assign(this, props);
+  }
+}
+
+// Generic generator for planets, moons and bases including their orbiting bodies
 export function generateStellarObject(
   kind,
   star = null,
@@ -15,35 +20,13 @@ export function generateStellarObject(
   parent = null,
   siblings = []
 ) {
-  if (kind === 'star') {
-    const type = STAR_TYPES[randomInt(0, STAR_TYPES.length - 1)];
-    const obj = {
-      class: type.class,
-      name: type.name,
-      color: STAR_CLASS_COLORS[type.class],
-      size: type.size,
-      mass: randomRange(type.mass[0], type.mass[1]),
-      luminosity: randomRange(type.luminosity[0], type.luminosity[1]),
-      radius: randomRange(type.radius[0], type.radius[1]),
-      habitableZone: type.habitableZone,
-      planets: []
-    };
-    const planetCount = randomInt(0, 10);
-    for (let i = 0; i < planetCount; i++) {
-      obj.planets.push(
-        generateStellarObject('planet', obj, i, null, obj.planets)
-      );
-    }
-    return obj;
-  }
-
   if (kind === 'base') {
     const orbitDistance = (orbitIndex + 1) * randomRange(0.001, 0.01);
     const distance = parent.distance + orbitDistance;
     const angle = Math.random() * Math.PI * 2;
     const eccentricity = Math.random() * 0.01;
     const orbitRotation = Math.random() * Math.PI * 2;
-    const body = {
+    const body = new StellarObject({
       name: `Base ${orbitIndex + 1}`,
       type: 'base',
       distance,
@@ -60,7 +43,7 @@ export function generateStellarObject(
       atmosphere: null,
       moons: [],
       population: Math.floor(randomRange(100, 1000))
-    };
+    });
     return body;
   }
 
@@ -121,7 +104,7 @@ export function generateStellarObject(
     return acc;
   }, {});
   const atmosphere = radius < 0.3 ? null : generateAtmosphere(type);
-  const body = {
+  const body = new StellarObject({
     name: parent ? `Moon ${orbitIndex + 1}` : `Planet ${orbitIndex + 1}`,
     type,
     distance,
@@ -136,7 +119,7 @@ export function generateStellarObject(
     resources,
     atmosphere,
     moons: []
-  };
+  });
   body.moons = generateChildren(star, body);
   return body;
 }
@@ -202,11 +185,11 @@ function selectRule(star, distance, prev) {
   return PLANET_TYPES[0];
 }
 
-function randomInt(min, max) {
+export function randomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-function randomRange(min, max) {
+export function randomRange(min, max) {
   return Math.random() * (max - min) + min;
 }
 

--- a/test/stellar-object.test.js
+++ b/test/stellar-object.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { generateStellarObject } from '../client/js/stellar-object.js';
+import { generateStar } from '../client/js/star.js';
 import { STAR_TYPES, STAR_CLASS_COLORS } from '../client/js/data/stars.js';
 import {
   PLANET_TYPES,
@@ -69,7 +69,7 @@ function validateBody(body, star) {
 }
 
 test('generate star with valid planets and moons', () => {
-  const star = generateStellarObject('star');
+  const star = generateStar();
   const starType = STAR_TYPES.find((s) => s.class === star.class);
   assert.ok(starType);
   assert.equal(star.name, starType.name);
@@ -88,7 +88,7 @@ test('generate star with valid planets and moons', () => {
 test('planet with five moons has unique moon radii', () => {
   let targetPlanet = null;
   for (let i = 0; i < 100 && !targetPlanet; i++) {
-    const star = generateStellarObject('star');
+    const star = generateStar();
     targetPlanet = star.planets.find(
       (p) => p.moons.filter((m) => m.type !== 'base').length === 5
     );


### PR DESCRIPTION
## Summary
- refactor object generation so star-specific logic lives in a new Star class
- update generic generator to handle planets, moons, and bases
- adjust tests to use the new star generator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891ef7656c8832ab8dbcf3d4f5ffdd2