### PR TITLE
Double icon sizes and label object types

### DIFF
--- a/client/js/components/galaxy-overview.js
+++ b/client/js/components/galaxy-overview.js
@@ -6,7 +6,7 @@ export function createGalaxyOverview(
   onOpenSystem,
   selectedSystem = null
 ) {
-  const STAR_RADIUS = 8;
+  const STAR_RADIUS = 16;
   const size = galaxy.size;
 
   const systems = galaxy.systems.map(({ x, y, system }) => ({
@@ -49,7 +49,7 @@ export function createGalaxyOverview(
         ctx.beginPath();
         ctx.strokeStyle = 'rgba(255,255,255,0.8)';
         ctx.lineWidth = 2;
-        ctx.arc(cx, cy, STAR_RADIUS + 3, 0, Math.PI * 2);
+        ctx.arc(cx, cy, STAR_RADIUS + 6, 0, Math.PI * 2);
         ctx.stroke();
       }
     });

--- a/client/js/components/planet-overview.js
+++ b/client/js/components/planet-overview.js
@@ -9,8 +9,8 @@ export function createPlanetOverview(
   height = 400
 ) {
   const objects = planet.moons || [];
-  const PLANET_RADIUS = 20; // constant radius for planet
-  const OBJECT_RADIUS = 8; // constant radius for moons and bases
+  const PLANET_RADIUS = 40; // constant radius for planet
+  const OBJECT_RADIUS = 16; // constant radius for moons and bases
 
   let planetRadius = PLANET_RADIUS;
   let objectData = [];
@@ -73,10 +73,20 @@ export function createPlanetOverview(
       if (obj.type === 'base') {
         ctx.fillStyle = '#fff';
         ctx.fillRect(px - objRadius, py - objRadius, objRadius * 2, objRadius * 2);
+        ctx.fillStyle = '#fff';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'bottom';
+        ctx.font = '12px sans-serif';
+        ctx.fillText('base', px, py - objRadius - 8);
       } else {
         ctx.fillStyle = PLANET_COLORS[obj.type] || '#fff';
         ctx.arc(px, py, objRadius, 0, Math.PI * 2);
         ctx.fill();
+        ctx.fillStyle = '#fff';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'bottom';
+        ctx.font = '12px sans-serif';
+        ctx.fillText(`${obj.type} ${obj.kind}`, px, py - objRadius - 8);
       }
     });
 
@@ -85,7 +95,7 @@ export function createPlanetOverview(
     ctx.arc(cx, cy, planetRadius, 0, Math.PI * 2);
     ctx.fill();
 
-    let iconX = cx + planetRadius + 4;
+    let iconX = cx + planetRadius + 8;
     const iconY = cy;
     if (planet.features) {
       planet.features
@@ -94,20 +104,26 @@ export function createPlanetOverview(
           ctx.fillStyle = '#fff';
           if (f === 'mine') {
             ctx.beginPath();
-            ctx.moveTo(iconX, iconY - 3);
-            ctx.lineTo(iconX + 4, iconY - 3);
-            ctx.lineTo(iconX + 2, iconY + 1);
+            ctx.moveTo(iconX, iconY - 6);
+            ctx.lineTo(iconX + 8, iconY - 6);
+            ctx.lineTo(iconX + 4, iconY + 2);
             ctx.fill();
           }
-          iconX += 6;
+          iconX += 12;
         });
     }
     if (planet.moons && planet.moons.length) {
       ctx.beginPath();
       ctx.fillStyle = '#fff';
-      ctx.arc(iconX + 2, iconY, 2, 0, Math.PI * 2);
+      ctx.arc(iconX + 4, iconY, 4, 0, Math.PI * 2);
       ctx.fill();
     }
+
+    ctx.fillStyle = '#fff';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    ctx.font = '12px sans-serif';
+    ctx.fillText(`${planet.type} planet`, cx, cy - planetRadius - 8);
 
     if (hoveredIndex !== null) {
       const { px, py, objRadius, obj } = objectData[hoveredIndex];
@@ -115,9 +131,9 @@ export function createPlanetOverview(
       ctx.strokeStyle = 'rgba(255,255,255,0.8)';
       ctx.lineWidth = 2;
       if (obj.type === 'base') {
-        ctx.strokeRect(px - objRadius - 2, py - objRadius - 2, objRadius * 2 + 4, objRadius * 2 + 4);
+        ctx.strokeRect(px - objRadius - 4, py - objRadius - 4, objRadius * 2 + 8, objRadius * 2 + 8);
       } else {
-        ctx.arc(px, py, objRadius + 3, 0, Math.PI * 2);
+        ctx.arc(px, py, objRadius + 6, 0, Math.PI * 2);
         ctx.stroke();
       }
     }

--- a/client/js/components/planet-sidebar.js
+++ b/client/js/components/planet-sidebar.js
@@ -22,13 +22,13 @@ export function createPlanetSidebar(planet) {
     ? `<table class="info-table"><thead><tr><th>Name</th><th>Type</th><th>Radius</th><th>Atmosphere</th></tr></thead><tbody>${moons
         .map(
           (m, i) =>
-            `<tr><td>${m.name || `Object ${i + 1}`}</td><td>${m.type}</td><td>${m.radius.toFixed(2)}</td><td>${m.atmosphere ? formatAtmosphere(m.atmosphere) : 'None'}</td></tr>`
+            `<tr><td>${m.name || `Object ${i + 1}`}</td><td>${m.type} ${m.kind}</td><td>${m.radius.toFixed(2)}</td><td>${m.atmosphere ? formatAtmosphere(m.atmosphere) : 'None'}</td></tr>`
         )
         .join('')}</tbody></table>`
     : '<p>None</p>';
 
   container.innerHTML = `
-    <h2>${planet.type}</h2>
+    <h2>${planet.type} ${planet.kind}</h2>
     <ul>
       <li><strong>Distance:</strong> ${planet.distance.toFixed(2)} AU</li>
       <li><strong>Radius:</strong> ${planet.radius.toFixed(2)}</li>

--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -10,8 +10,8 @@ export function createSystemOverview(
 ) {
   const star = system.stars[0];
   const planets = system.planets;
-  const STAR_SCALE = 12;
-  const PLANET_RADIUS = 8; // constant radius for all planets
+  const STAR_SCALE = 24;
+  const PLANET_RADIUS = 16; // constant radius for all planets
 
   const baseStarRadius = star.size * 2 * STAR_SCALE;
   const basePlanetRadius = PLANET_RADIUS;
@@ -87,29 +87,35 @@ export function createSystemOverview(
       ctx.arc(px, py, planetRadius, 0, Math.PI * 2);
       ctx.fill();
 
-      let iconX = px + planetRadius + 4;
+      let iconX = px + planetRadius + 8;
       const iconY = py;
       if (planet.features) {
         planet.features.forEach((f) => {
           ctx.fillStyle = '#fff';
           if (f === 'base') {
-            ctx.fillRect(iconX, iconY - 2, 4, 4);
+            ctx.fillRect(iconX, iconY - 4, 8, 8);
           } else if (f === 'mine') {
             ctx.beginPath();
-            ctx.moveTo(iconX, iconY - 3);
-            ctx.lineTo(iconX + 4, iconY - 3);
-            ctx.lineTo(iconX + 2, iconY + 1);
+            ctx.moveTo(iconX, iconY - 6);
+            ctx.lineTo(iconX + 8, iconY - 6);
+            ctx.lineTo(iconX + 4, iconY + 2);
             ctx.fill();
           }
-          iconX += 6;
+          iconX += 12;
         });
       }
       if (planet.moons && planet.moons.length) {
         ctx.beginPath();
         ctx.fillStyle = '#fff';
-        ctx.arc(iconX + 2, iconY, 2, 0, Math.PI * 2);
+        ctx.arc(iconX + 4, iconY, 4, 0, Math.PI * 2);
         ctx.fill();
       }
+
+      ctx.fillStyle = '#fff';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      ctx.font = '12px sans-serif';
+      ctx.fillText(`${planet.type} planet`, px, py - planetRadius - 8);
     });
 
     ctx.beginPath();
@@ -122,7 +128,7 @@ export function createSystemOverview(
       ctx.beginPath();
       ctx.strokeStyle = 'rgba(255,255,255,0.8)';
       ctx.lineWidth = 2;
-      ctx.arc(px, py, planetRadius + 3, 0, Math.PI * 2);
+      ctx.arc(px, py, planetRadius + 6, 0, Math.PI * 2);
       ctx.stroke();
     }
   }

--- a/client/js/stellar-object.js
+++ b/client/js/stellar-object.js
@@ -28,6 +28,7 @@ export function generateStellarObject(
     const orbitRotation = Math.random() * Math.PI * 2;
     const body = new StellarObject({
       name: `Base ${orbitIndex + 1}`,
+      kind: 'base',
       type: 'base',
       distance,
       orbitDistance,
@@ -106,6 +107,7 @@ export function generateStellarObject(
   const atmosphere = radius < 0.3 ? null : generateAtmosphere(type);
   const body = new StellarObject({
     name: parent ? `Moon ${orbitIndex + 1}` : `Planet ${orbitIndex + 1}`,
+    kind,
     type,
     distance,
     radius,

--- a/test/stellar-object.test.js
+++ b/test/stellar-object.test.js
@@ -101,3 +101,17 @@ test('planet with five moons has unique moon radii', () => {
     }
   }
 });
+
+test('generated bodies include kind property', () => {
+  const star = generateStar();
+  star.planets.forEach((p) => {
+    assert.equal(p.kind, 'planet');
+    p.moons.forEach((m) => {
+      if (m.type === 'base') {
+        assert.equal(m.kind, 'base');
+      } else {
+        assert.equal(m.kind, 'moon');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Tag generated stellar objects with a `kind` field and surface it in the planet sidebar and tables.
- Enlarge star, planet, moon, and feature icons across galaxy, system, and planet overviews while annotating planets and moons with their type names.
- Add test to ensure all generated bodies include a `kind` property.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891f461cde8832aaa60a567599edef4