### PR TITLE
Add unique names for celestial bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Spacecraft can be sent to planets within a star system and outside to other star
 There will be three levels of scale; 1) Galactic, which is a 2d grid of all visible star systems, 2) System, which is a 2d view of star, planets and other large objects within the system, depicted as concentric orbits, with current spacecraft courses plotted on top.
 The planets will be randomly generated, a bit like StarGen-II but with fewer properties. Each planet will have a number of resources that can be mined if a mining ship is sent to it. One planet in the player's starting system must be earth-like, and it is here the player has its first base.
 
+Stars, planets and moons are given names procedurally. Stars always receive unique names, while planets and moons usually take their parent's name followed by a Roman numeral, though occasionally they are assigned unique names of their own.
+
 The client will be HTML/CSS with less.js for any ES6 JS logic needed.
 
 The server will be Node.js > 20.0 ES6, no build systems, no types, just basic libraries for HTTP APIs, CORS and Postgres ORM.

--- a/client/js/name-generator.js
+++ b/client/js/name-generator.js
@@ -1,0 +1,42 @@
+import { uniqueNamesGenerator, adjectives, animals } from 'unique-names-generator';
+
+export function generateUniqueName() {
+  return uniqueNamesGenerator({
+    dictionaries: [adjectives, animals],
+    style: 'capital',
+    separator: ' '
+  });
+}
+
+export function toRoman(num) {
+  const romans = [
+    ['M', 1000],
+    ['CM', 900],
+    ['D', 500],
+    ['CD', 400],
+    ['C', 100],
+    ['XC', 90],
+    ['L', 50],
+    ['XL', 40],
+    ['X', 10],
+    ['IX', 9],
+    ['V', 5],
+    ['IV', 4],
+    ['I', 1]
+  ];
+  let result = '';
+  for (const [letter, value] of romans) {
+    while (num >= value) {
+      result += letter;
+      num -= value;
+    }
+  }
+  return result;
+}
+
+export function generateBodyName(parentName, orbitIndex) {
+  if (Math.random() < 0.3) {
+    return generateUniqueName();
+  }
+  return `${parentName} ${toRoman(orbitIndex + 1)}`;
+}

--- a/client/js/star.js
+++ b/client/js/star.js
@@ -1,12 +1,14 @@
 import { STAR_TYPES, STAR_CLASS_COLORS } from './data/stars.js';
 import { generateStellarObject, randomInt, randomRange, StellarObject } from './stellar-object.js';
+import { generateUniqueName } from './name-generator.js';
 
 export class Star extends StellarObject {
   constructor() {
     const type = STAR_TYPES[randomInt(0, STAR_TYPES.length - 1)];
     super({
       class: type.class,
-      name: type.name,
+      typeName: type.name,
+      name: generateUniqueName(),
       color: STAR_CLASS_COLORS[type.class],
       size: type.size,
       mass: randomRange(type.mass[0], type.mass[1]),

--- a/client/js/stellar-object.js
+++ b/client/js/stellar-object.js
@@ -5,6 +5,7 @@ import {
   PLANET_ATMOSPHERES,
   MOON_RULES
 } from './data/planets.js';
+import { generateBodyName } from './name-generator.js';
 
 export class StellarObject {
   constructor(props) {
@@ -105,8 +106,9 @@ export function generateStellarObject(
     return acc;
   }, {});
   const atmosphere = radius < 0.3 ? null : generateAtmosphere(type);
+  const name = generateBodyName(parent ? parent.name : star.name, orbitIndex);
   const body = new StellarObject({
-    name: parent ? `Moon ${orbitIndex + 1}` : `Planet ${orbitIndex + 1}`,
+    name,
     kind,
     type,
     distance,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "whimsical",
       "version": "1.0.0",
+      "dependencies": {
+        "unique-names-generator": "^4.7.1"
+      },
       "devDependencies": {
         "jsdom": "^26.1.0"
       }
@@ -439,6 +442,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/unique-names-generator": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/unique-names-generator/-/unique-names-generator-4.7.1.tgz",
+      "integrity": "sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   },
   "devDependencies": {
     "jsdom": "^26.1.0"
+  },
+  "dependencies": {
+    "unique-names-generator": "^4.7.1"
   }
 }

--- a/test/stellar-object.test.js
+++ b/test/stellar-object.test.js
@@ -31,7 +31,7 @@ function validateBody(body, star) {
   }
   assert.ok(planetTypeNames.includes(body.type));
   const rule = PLANET_TYPES.find((t) => t.name === body.type);
-  if (body.name.startsWith('Planet')) {
+  if (body.kind === 'planet') {
     assert.ok(body.radius >= rule.radius[0] && body.radius <= rule.radius[1]);
   }
   assert.ok(body.distance > 0);
@@ -72,7 +72,9 @@ test('generate star with valid planets and moons', () => {
   const star = generateStar();
   const starType = STAR_TYPES.find((s) => s.class === star.class);
   assert.ok(starType);
-  assert.equal(star.name, starType.name);
+  assert.equal(star.typeName, starType.name);
+  assert.ok(typeof star.name === 'string');
+  assert.ok(star.name.length > 0);
   assert.equal(star.color, STAR_CLASS_COLORS[star.class]);
   assert.ok(star.mass >= starType.mass[0] && star.mass <= starType.mass[1]);
   assert.ok(


### PR DESCRIPTION
## Summary
- Install **unique-names-generator** and add utility to build random names and Roman numerals
- Stars always get a generated name and keep their stellar classification separately
- Planets and moons usually inherit their parent name with a Roman numeral, but sometimes receive unique names
- Document naming rules and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689210487520832a91474e39cdffcfb9