### PR TITLE
fix: use relative path for unique-names-generator

### DIFF
--- a/client/js/name-generator.js
+++ b/client/js/name-generator.js
@@ -1,4 +1,11 @@
-import { uniqueNamesGenerator, adjectives, animals } from 'unique-names-generator';
+// Import the module using a relative path so that the browser can resolve it
+// without a bundler or import maps. This fixes the "bare specifier" error
+// when `name-generator.js` is loaded in the browser.
+import {
+  uniqueNamesGenerator,
+  adjectives,
+  animals
+} from '../../node_modules/unique-names-generator/dist/index.m.js';
 
 export function generateUniqueName() {
   return uniqueNamesGenerator({


### PR DESCRIPTION
## Summary
- resolve unique-names-generator via relative path so browser can load it without import maps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689212d59a58832a9c72ce16e3f8a587