### PR TITLE
Fix star name module path and add star naming test

### DIFF
--- a/client/js/name-generator.js
+++ b/client/js/name-generator.js
@@ -1,11 +1,14 @@
 // Import the module using a relative path so that the browser can resolve it
 // without a bundler or import maps. This fixes the "bare specifier" error
 // when `name-generator.js` is loaded in the browser.
+// Use the modern ES module build that ends with `.js` so that static servers
+// correctly set the `Content-Type` header. The previous `index.m.js` extension
+// caused the browser to block the module due to an empty MIME type.
 import {
   uniqueNamesGenerator,
   adjectives,
   animals
-} from '../../node_modules/unique-names-generator/dist/index.m.js';
+} from '../../node_modules/unique-names-generator/dist/index.modern.js';
 
 export function generateUniqueName() {
   return uniqueNamesGenerator({

--- a/test/star-name.test.js
+++ b/test/star-name.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { generateStar } from '../client/js/star.js';
+
+// Ensure that generated stars receive a readable two-word name.
+test('generateStar assigns a two-word name', () => {
+  const star = generateStar();
+  assert.equal(typeof star.name, 'string');
+  const words = star.name.split(' ');
+  assert.equal(words.length, 2);
+  assert.match(words[0], /^[A-Z][a-z]*$/);
+  assert.match(words[1], /^[A-Z][a-z]*$/);
+});


### PR DESCRIPTION
## Summary
- load `unique-names-generator` using the modern ES module build so browsers receive a proper MIME type
- add test verifying generated stars have two-word names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689215f66b0c832abc95398aa8c569d1