### PR TITLE
Implement hierarchical naming and display names

### DIFF
--- a/client/js/components/planet-overview.js
+++ b/client/js/components/planet-overview.js
@@ -77,7 +77,7 @@ export function createPlanetOverview(
         ctx.textAlign = 'center';
         ctx.textBaseline = 'bottom';
         ctx.font = '12px sans-serif';
-        ctx.fillText('base', px, py - objRadius - 8);
+        ctx.fillText(obj.name, px, py - objRadius - 8);
       } else {
         ctx.fillStyle = PLANET_COLORS[obj.type] || '#fff';
         ctx.arc(px, py, objRadius, 0, Math.PI * 2);
@@ -86,7 +86,7 @@ export function createPlanetOverview(
         ctx.textAlign = 'center';
         ctx.textBaseline = 'bottom';
         ctx.font = '12px sans-serif';
-        ctx.fillText(`${obj.type} ${obj.kind}`, px, py - objRadius - 8);
+        ctx.fillText(obj.name, px, py - objRadius - 8);
       }
     });
 
@@ -123,7 +123,7 @@ export function createPlanetOverview(
     ctx.textAlign = 'center';
     ctx.textBaseline = 'bottom';
     ctx.font = '12px sans-serif';
-    ctx.fillText(`${planet.type} planet`, cx, cy - planetRadius - 8);
+    ctx.fillText(planet.name, cx, cy - planetRadius - 8);
 
     if (hoveredIndex !== null) {
       const { px, py, objRadius, obj } = objectData[hoveredIndex];
@@ -142,7 +142,7 @@ export function createPlanetOverview(
   const overview = createOverview({
     update: updateLayout,
     draw,
-    label: 'Planet',
+    label: planet.name,
   });
 
   canvas = overview.canvas;

--- a/client/js/components/planet-sidebar.js
+++ b/client/js/components/planet-sidebar.js
@@ -30,7 +30,8 @@ export function createPlanetSidebar(planet) {
 
   container.innerHTML = `
     <div class="sidebar-label">${labelText}</div>
-    <h2>${planet.type} ${planet.kind}</h2>
+    <h2>${planet.name}</h2>
+    <div class="object-type">${planet.type} ${planet.kind}</div>
     <ul>
       <li><strong>Distance:</strong> ${planet.distance.toFixed(2)} AU</li>
       <li><strong>Radius:</strong> ${planet.radius.toFixed(2)}</li>

--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -119,7 +119,7 @@ export function createSystemOverview(
       ctx.textAlign = 'center';
       ctx.textBaseline = 'bottom';
       ctx.font = '12px sans-serif';
-      ctx.fillText(`${planet.type} planet`, px, py - planetRadius - 8);
+      ctx.fillText(planet.name, px, py - planetRadius - 8);
 
       if (idx === hoveredIndex || idx === selectedIndex) {
         ctx.beginPath();
@@ -139,7 +139,7 @@ export function createSystemOverview(
   const overview = createOverview({
     update: updateLayout,
     draw,
-    label: 'Star System',
+    label: star.name,
   });
 
   canvas = overview.canvas;

--- a/client/js/name-generator.js
+++ b/client/js/name-generator.js
@@ -44,9 +44,24 @@ export function toRoman(num) {
   return result;
 }
 
-export function generateBodyName(parentName, orbitIndex) {
-  if (Math.random() < 0.3) {
-    return generateUniqueName();
+export function generateBodyName(starName, orbitIndex, parent = null) {
+  if (!parent) {
+    // planet naming: 70% star name + numeral, 30% unique
+    if (Math.random() < 0.3) {
+      return generateUniqueName();
+    }
+    return `${starName} ${toRoman(orbitIndex + 1)}`;
   }
-  return `${parentName} ${toRoman(orbitIndex + 1)}`;
+
+  const planetHasOwnName = !parent.name.startsWith(`${starName} `);
+  if (planetHasOwnName) {
+    // moon around a uniquely named planet: 70% planet name + numeral
+    if (Math.random() < 0.3) {
+      return generateUniqueName();
+    }
+    return `${parent.name} ${toRoman(orbitIndex + 1)}`;
+  }
+
+  // moon around a star-named planet always has its own name
+  return generateUniqueName();
 }

--- a/client/js/stellar-object.js
+++ b/client/js/stellar-object.js
@@ -106,7 +106,7 @@ export function generateStellarObject(
     return acc;
   }, {});
   const atmosphere = radius < 0.3 ? null : generateAtmosphere(type);
-  const name = generateBodyName(parent ? parent.name : star.name, orbitIndex);
+  const name = generateBodyName(star.name, orbitIndex, parent);
   const body = new StellarObject({
     name,
     kind,


### PR DESCRIPTION
## Summary
- Implement hierarchical naming rules for planets and moons
- Show object names in system and planet overviews and sidebars

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689221d6f268832abf5e5148165c6a3b