### PR TITLE
Add gravity to stellar objects and Celsius conversion

### DIFF
--- a/client/js/components/base-sidebar.js
+++ b/client/js/components/base-sidebar.js
@@ -8,6 +8,7 @@ export function createBaseSidebar(base) {
     <ul>
       <li><strong>Orbit Distance:</strong> ${orbit.toFixed(3)} AU</li>
       <li><strong>Radius:</strong> ${base.radius.toFixed(2)}</li>
+      <li><strong>Gravity:</strong> ${base.gravity.toFixed(2)} g</li>
       <li><strong>Population:</strong> ${base.population}</li>
     </ul>
   `;

--- a/client/js/components/planet-sidebar.js
+++ b/client/js/components/planet-sidebar.js
@@ -35,7 +35,8 @@ export function createPlanetSidebar(planet) {
     <ul>
       <li><strong>Distance:</strong> ${planet.distance.toFixed(2)} AU</li>
       <li><strong>Radius:</strong> ${planet.radius.toFixed(2)}</li>
-      <li><strong>Temperature:</strong> ${planet.temperature.toFixed(2)} K</li>
+      <li><strong>Gravity:</strong> ${planet.gravity.toFixed(2)} g</li>
+      <li><strong>Temperature:</strong> ${planet.temperature.toFixed(2)} K (${(planet.temperature - 273.15).toFixed(2)} °C)</li>
       <li><strong>Habitable:</strong> ${planet.isHabitable ? 'Yes' : 'No'}</li>
       <li><strong>Orbital Period:</strong> ${planet.orbitalPeriod.toFixed(2)} years</li>
       <li><strong>Eccentricity:</strong> ${planet.eccentricity.toFixed(2)}</li>

--- a/client/js/components/star-sidebar.js
+++ b/client/js/components/star-sidebar.js
@@ -10,6 +10,7 @@ export function createStarSidebar(system, onGoToSystem) {
       <li><strong>Mass:</strong> ${star.mass.toFixed(2)} M☉</li>
       <li><strong>Luminosity:</strong> ${star.luminosity.toFixed(2)} L☉</li>
       <li><strong>Radius:</strong> ${star.radius.toFixed(2)} R☉</li>
+      <li><strong>Gravity:</strong> ${star.gravity.toFixed(2)} g</li>
       <li><strong>Habitable Zone:</strong> ${star.habitableZone[0].toFixed(2)} - ${star.habitableZone[1].toFixed(2)} AU</li>
     </ul>
   `;

--- a/client/js/star.js
+++ b/client/js/star.js
@@ -5,15 +5,18 @@ import { generateUniqueName } from './name-generator.js';
 export class Star extends StellarObject {
   constructor() {
     const type = STAR_TYPES[randomInt(0, STAR_TYPES.length - 1)];
+    const mass = randomRange(type.mass[0], type.mass[1]);
+    const radius = randomRange(type.radius[0], type.radius[1]);
     super({
       class: type.class,
       typeName: type.name,
       name: generateUniqueName(),
       color: STAR_CLASS_COLORS[type.class],
       size: type.size,
-      mass: randomRange(type.mass[0], type.mass[1]),
+      mass,
       luminosity: randomRange(type.luminosity[0], type.luminosity[1]),
-      radius: randomRange(type.radius[0], type.radius[1]),
+      radius,
+      gravity: mass / Math.pow(radius, 2),
       habitableZone: type.habitableZone
     });
     this.planets = [];

--- a/client/js/stellar-object.js
+++ b/client/js/stellar-object.js
@@ -34,6 +34,7 @@ export function generateStellarObject(
       distance,
       orbitDistance,
       radius: 0.05,
+      gravity: parent.gravity,
       temperature: parent.temperature,
       isHabitable: true,
       orbitalPeriod: Math.sqrt(Math.pow(distance, 3) / star.mass),
@@ -89,6 +90,8 @@ export function generateStellarObject(
 
   const temperature =
     278 * Math.pow(star.luminosity, 0.25) / Math.sqrt(distance);
+  const mass = Math.pow(radius, 3);
+  const gravity = mass / Math.pow(radius, 2);
   const isHabitable =
     type === 'terrestrial' &&
     distance >= star.habitableZone[0] &&
@@ -113,6 +116,8 @@ export function generateStellarObject(
     type,
     distance,
     radius,
+    gravity,
+    mass,
     temperature,
     isHabitable,
     orbitalPeriod,

--- a/client/test/planet-sidebar.test.js
+++ b/client/test/planet-sidebar.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { createPlanetSidebar } from '../js/components/planet-sidebar.js';
+
+// Ensure planet sidebar displays gravity and temperature in both Kelvin and Celsius
+// Requires DOM environment via JSDOM
+
+test('planet sidebar shows gravity and celsius conversion', () => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+  global.document = dom.window.document;
+
+  const planet = {
+    name: 'Test',
+    type: 'rocky',
+    kind: 'planet',
+    distance: 1,
+    radius: 1,
+    gravity: 1,
+    temperature: 300,
+    isHabitable: false,
+    orbitalPeriod: 1,
+    eccentricity: 0,
+    features: [],
+    resources: {},
+    atmosphere: null,
+    moons: []
+  };
+
+  const sidebar = createPlanetSidebar(planet);
+  const html = sidebar.innerHTML;
+  assert.match(html, /Gravity:<\/strong> 1\.00 g/);
+  assert.match(html, /Temperature:<\/strong> 300\.00 K \(26\.85 °C\)/);
+
+  delete global.document;
+});

--- a/client/test/stellar-object.test.js
+++ b/client/test/stellar-object.test.js
@@ -23,12 +23,17 @@ function expectedMaxMoons(radius) {
   return 0;
 }
 
-function validateBody(body, star) {
+function validateBody(body, star, parent = null) {
   if (body.type === 'base') {
     assert.ok(body.distance > 0);
     assert.ok(typeof body.radius === 'number');
+    assert.ok(typeof body.gravity === 'number');
+    if (parent) {
+      assert.equal(body.gravity, parent.gravity);
+    }
     return;
   }
+  assert.ok(typeof body.gravity === 'number');
   assert.ok(planetTypeNames.includes(body.type));
   const rule = PLANET_TYPES.find((t) => t.name === body.type);
   if (body.kind === 'planet') {
@@ -65,7 +70,7 @@ function validateBody(body, star) {
   const naturalMoons = body.moons.filter((m) => m.type !== 'base');
   const maxMoons = expectedMaxMoons(body.radius);
   assert.ok(naturalMoons.length <= maxMoons);
-  body.moons.forEach((m) => validateBody(m, star));
+  body.moons.forEach((m) => validateBody(m, star, body));
 }
 
 test('generate star with valid planets and moons', () => {
@@ -82,6 +87,8 @@ test('generate star with valid planets and moons', () => {
       star.luminosity <= starType.luminosity[1]
   );
   assert.ok(star.radius >= starType.radius[0] && star.radius <= starType.radius[1]);
+  const expectedGravity = star.mass / (star.radius * star.radius);
+  assert.ok(Math.abs(star.gravity - expectedGravity) < 1e-6);
   assert.ok(Array.isArray(star.planets));
   assert.ok(star.planets.length >= 0 && star.planets.length <= 10);
   star.planets.forEach((p) => validateBody(p, star));


### PR DESCRIPTION
## Summary
- compute gravity for stars, planets, moons and bases
- show gravity in sidebars and display temperature in both Kelvin and Celsius
- test gravity generation and temperature conversion

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68922402a5e0832a8e8c9801f657a39d