### PR TITLE
Randomize stellar gravity and show star names on hover

### DIFF
--- a/client/js/components/galaxy-overview.js
+++ b/client/js/components/galaxy-overview.js
@@ -53,6 +53,21 @@ export function createGalaxyOverview(
         ctx.stroke();
       }
     });
+
+    if (hoveredIndex !== null) {
+      const { cx, cy, star } = starPositions[hoveredIndex];
+      const text = star.name;
+      ctx.font = '16px sans-serif';
+      ctx.textBaseline = 'top';
+      const textWidth = ctx.measureText(text).width;
+      const padding = 4;
+      const x = cx - textWidth / 2 - padding;
+      const y = cy - STAR_RADIUS - 8 - 16 - padding;
+      ctx.fillStyle = 'rgba(0,0,0,0.7)';
+      ctx.fillRect(x, y, textWidth + padding * 2, 16 + padding * 2);
+      ctx.fillStyle = '#fff';
+      ctx.fillText(text, x + padding, y + padding);
+    }
   }
 
   const overview = createOverview({

--- a/client/js/star.js
+++ b/client/js/star.js
@@ -7,6 +7,8 @@ export class Star extends StellarObject {
     const type = STAR_TYPES[randomInt(0, STAR_TYPES.length - 1)];
     const mass = randomRange(type.mass[0], type.mass[1]);
     const radius = randomRange(type.radius[0], type.radius[1]);
+    const minGravity = type.mass[0] / Math.pow(type.radius[1], 2);
+    const maxGravity = type.mass[1] / Math.pow(type.radius[0], 2);
     super({
       class: type.class,
       typeName: type.name,
@@ -16,7 +18,7 @@ export class Star extends StellarObject {
       mass,
       luminosity: randomRange(type.luminosity[0], type.luminosity[1]),
       radius,
-      gravity: mass / Math.pow(radius, 2),
+      gravity: randomRange(minGravity, maxGravity),
       habitableZone: type.habitableZone
     });
     this.planets = [];

--- a/client/js/stellar-object.js
+++ b/client/js/stellar-object.js
@@ -91,7 +91,7 @@ export function generateStellarObject(
   const temperature =
     278 * Math.pow(star.luminosity, 0.25) / Math.sqrt(distance);
   const mass = Math.pow(radius, 3);
-  const gravity = mass / Math.pow(radius, 2);
+  const gravity = randomRange(0.1, 3);
   const isHabitable =
     type === 'terrestrial' &&
     distance >= star.habitableZone[0] &&

--- a/client/test/galaxy-hover.test.js
+++ b/client/test/galaxy-hover.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { createGalaxyOverview } from '../js/components/galaxy-overview.js';
+import { generateStar } from '../js/star.js';
+
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    pretendToBeVisual: true,
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.window.devicePixelRatio = 1;
+  dom.window.HTMLCanvasElement.prototype.getContext = () => ctxStub;
+  dom.window.HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    width: 300,
+    height: 300,
+    left: 0,
+    top: 0,
+  });
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      setTimeout(() => this.cb(), 0);
+    }
+    disconnect() {}
+  };
+  global.requestAnimationFrame = (fn) => setTimeout(fn, 0);
+}
+
+let capturedText = null;
+const ctxStub = {
+  setTransform() {},
+  fillRect() {},
+  beginPath() {},
+  arc() {},
+  fill() {},
+  stroke() {},
+  measureText: () => ({ width: 50 }),
+  fillText: (text) => {
+    capturedText = text;
+  },
+};
+
+test('hovering over star displays its name', async () => {
+  setupDom();
+  const star = generateStar();
+  const galaxy = {
+    size: 1,
+    systems: [{ x: 0, y: 0, system: { stars: [star] } }],
+  };
+
+  const overview = createGalaxyOverview(galaxy);
+  document.body.appendChild(overview);
+
+  await new Promise((r) => setTimeout(r, 0));
+
+  const canvas = overview.querySelector('canvas');
+  const event = new window.MouseEvent('mousemove', {
+    clientX: 100,
+    clientY: 100,
+  });
+  canvas.dispatchEvent(event);
+
+  assert.equal(capturedText, star.name);
+
+  delete global.window;
+  delete global.document;
+  delete global.ResizeObserver;
+  delete global.requestAnimationFrame;
+});
+

--- a/client/test/stellar-object.test.js
+++ b/client/test/stellar-object.test.js
@@ -87,8 +87,11 @@ test('generate star with valid planets and moons', () => {
       star.luminosity <= starType.luminosity[1]
   );
   assert.ok(star.radius >= starType.radius[0] && star.radius <= starType.radius[1]);
-  const expectedGravity = star.mass / (star.radius * star.radius);
-  assert.ok(Math.abs(star.gravity - expectedGravity) < 1e-6);
+  const minGravity =
+    starType.mass[0] / Math.pow(starType.radius[1], 2);
+  const maxGravity =
+    starType.mass[1] / Math.pow(starType.radius[0], 2);
+  assert.ok(star.gravity >= minGravity && star.gravity <= maxGravity);
   assert.ok(Array.isArray(star.planets));
   assert.ok(star.planets.length >= 0 && star.planets.length <= 10);
   star.planets.forEach((p) => validateBody(p, star));


### PR DESCRIPTION
## Summary
- Decouple stellar gravity from radius by sampling within type-based bounds
- Randomize planetary gravity generation
- Display star name badge when hovering in galaxy overview
- Add regression test for hover label and adjust existing gravity tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6892310d5d50832a9cfa7bcf613fa2e4