### PR TITLE
Show star details on click with glowing half-size star

### DIFF
--- a/client/js/components/star-sidebar.js
+++ b/client/js/components/star-sidebar.js
@@ -15,14 +15,14 @@ export function createStarSidebar(system, onGoToSystem) {
     </ul>
   `;
 
-  const btn = document.createElement('button');
-  btn.textContent = 'Go to system';
-  btn.addEventListener('click', () => {
-    if (typeof onGoToSystem === 'function') {
+  if (typeof onGoToSystem === 'function') {
+    const btn = document.createElement('button');
+    btn.textContent = 'Go to system';
+    btn.addEventListener('click', () => {
       onGoToSystem(system);
-    }
-  });
-  container.appendChild(btn);
+    });
+    container.appendChild(btn);
+  }
   return container;
 }
 

--- a/client/js/components/system-overview.js
+++ b/client/js/components/system-overview.js
@@ -6,13 +6,14 @@ export function createSystemOverview(
   onBack,
   onSelect,
   onOpenPlanet,
+  onSelectStar,
   selectedPlanet = null,
   width = 400,
   height = 400
 ) {
   const star = system.stars[0];
   const planets = system.planets;
-  const STAR_SCALE = 24;
+  const STAR_SCALE = 12;
   const PLANET_RADIUS = 16; // constant radius for all planets
 
   const baseStarRadius = star.size * 2 * STAR_SCALE;
@@ -130,10 +131,14 @@ export function createSystemOverview(
       }
     });
 
+    ctx.save();
     ctx.beginPath();
+    ctx.shadowBlur = starRadius * 2;
+    ctx.shadowColor = star.color;
     ctx.fillStyle = star.color;
     ctx.arc(cx, cy, starRadius, 0, Math.PI * 2);
     ctx.fill();
+    ctx.restore();
   }
 
   const overview = createOverview({
@@ -159,6 +164,18 @@ export function createSystemOverview(
     });
   }
 
+  function isStarClicked(event) {
+    const rect = canvas.getBoundingClientRect();
+    const scale = canvas.width / rect.width;
+    const x = (event.clientX - rect.left) * scale;
+    const y = (event.clientY - rect.top) * scale;
+    const cx = canvas.width / 2;
+    const cy = canvas.height / 2;
+    const dx = cx - x;
+    const dy = cy - y;
+    return Math.sqrt(dx * dx + dy * dy) <= starRadius;
+  }
+
   canvas.addEventListener('mousemove', (e) => {
     const idx = getPlanetIndex(e);
     hoveredIndex = idx === -1 ? null : idx;
@@ -180,6 +197,12 @@ export function createSystemOverview(
         selectedIndex = idx;
         if (typeof onSelect === 'function') {
           onSelect(planetData[idx].planet);
+        }
+        draw();
+      } else if (isStarClicked(e)) {
+        selectedIndex = null;
+        if (typeof onSelectStar === 'function') {
+          onSelectStar(star);
         }
         draw();
       }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -53,6 +53,10 @@ function init() {
         setSidebarContent(sidebar, planetContent);
       },
       (planet) => showPlanet(system, planet),
+      () => {
+        const starContent = createStarSidebar(system);
+        setSidebarContent(sidebar, starContent);
+      },
       selectedPlanet,
       overview.offsetWidth,
       overview.offsetHeight

--- a/client/test/star-sidebar-button.test.js
+++ b/client/test/star-sidebar-button.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { createStarSidebar } from '../js/components/star-sidebar.js';
+import { generateStarSystem } from '../js/galaxy.js';
+
+test('star sidebar omits button when no callback provided', () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  const system = generateStarSystem();
+  const sidebar = createStarSidebar(system);
+  const btn = sidebar.querySelector('button');
+  assert.equal(btn, null);
+  delete global.window;
+  delete global.document;
+});

--- a/client/test/system-star-click.test.js
+++ b/client/test/system-star-click.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { createSystemOverview } from '../js/components/system-overview.js';
+import { generateStarSystem } from '../js/galaxy.js';
+
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    pretendToBeVisual: true,
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.window.devicePixelRatio = 1;
+  const ctxStub = {
+    setTransform() {},
+    fillRect() {},
+    beginPath() {},
+    arc() {},
+    ellipse() {},
+    fill() {},
+    stroke() {},
+    moveTo() {},
+    lineTo() {},
+    save() {},
+    restore() {},
+    fillText() {},
+  };
+  dom.window.HTMLCanvasElement.prototype.getContext = () => ctxStub;
+  dom.window.HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    width: 300,
+    height: 300,
+    left: 0,
+    top: 0,
+  });
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      setTimeout(() => this.cb(), 0);
+    }
+    disconnect() {}
+  };
+  global.requestAnimationFrame = (fn) => setTimeout(fn, 0);
+}
+
+test('clicking star triggers star callback', async () => {
+  setupDom();
+  const system = generateStarSystem();
+  system.planets = [];
+  system.stars[0].planets = [];
+  let called = false;
+  const overview = createSystemOverview(
+    system,
+    null,
+    null,
+    null,
+    () => {
+      called = true;
+    },
+    null,
+    300,
+    300
+  );
+  document.body.appendChild(overview);
+
+  await new Promise((r) => setTimeout(r, 0));
+
+  const canvas = overview.querySelector('canvas');
+  const event = new window.MouseEvent('click', {
+    clientX: 150,
+    clientY: 150,
+  });
+  canvas.dispatchEvent(event);
+
+  await new Promise((r) => setTimeout(r, 300));
+
+  assert.equal(called, true);
+
+  delete global.window;
+  delete global.document;
+  delete global.ResizeObserver;
+  delete global.requestAnimationFrame;
+});


### PR DESCRIPTION
## Summary
- halve star size and add glow in system overview
- show star details in sidebar when the star is clicked
- render star sidebar button only when navigation callback exists
- cover star interaction with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892350336f4832a92ed044d93a970dd