### PR TITLE
Include gravity and temperature in habitability

### DIFF
--- a/docs/js/stellar-object.js
+++ b/docs/js/stellar-object.js
@@ -95,7 +95,11 @@ export function generateStellarObject(
   const isHabitable =
     type === 'terrestrial' &&
     distance >= star.habitableZone[0] &&
-    distance <= star.habitableZone[1];
+    distance <= star.habitableZone[1] &&
+    gravity >= 0.5 &&
+    gravity <= 1.5 &&
+    temperature >= 260 &&
+    temperature <= 320;
   const orbitalPeriod = Math.sqrt(Math.pow(distance, 3) / star.mass); // in Earth years
   const features = PLANET_FEATURES.filter((f) => Math.random() < f.chance).map(
     (f) => f.name

--- a/docs/test/stellar-object.test.js
+++ b/docs/test/stellar-object.test.js
@@ -30,10 +30,12 @@ function validateBody(body, star, parent = null) {
     assert.ok(typeof body.gravity === 'number');
     if (parent) {
       assert.equal(body.gravity, parent.gravity);
+      assert.equal(body.temperature, parent.temperature);
     }
     return;
   }
   assert.ok(typeof body.gravity === 'number');
+  assert.ok(typeof body.temperature === 'number');
   assert.ok(planetTypeNames.includes(body.type));
   const rule = PLANET_TYPES.find((t) => t.name === body.type);
   if (body.kind === 'planet') {
@@ -61,7 +63,9 @@ function validateBody(body, star, parent = null) {
   const inHZ =
     body.distance >= star.habitableZone[0] &&
     body.distance <= star.habitableZone[1];
-  if (body.type === 'terrestrial' && inHZ) {
+  const gravityOk = body.gravity >= 0.5 && body.gravity <= 1.5;
+  const tempOk = body.temperature >= 260 && body.temperature <= 320;
+  if (body.type === 'terrestrial' && inHZ && gravityOk && tempOk) {
     assert.equal(body.isHabitable, true);
   } else {
     assert.equal(body.isHabitable, false);


### PR DESCRIPTION
## Summary
- account for gravity and temperature when determining if a planet or moon is habitable
- verify habitable bodies in tests consider distance, gravity, and temperature

## Testing
- `cd docs && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892391a6204832a98ea4b1c7dc98465