### PR TITLE
Add star temperature modifiers and adjust planet type rules

### DIFF
--- a/docs/js/data/planets.js
+++ b/docs/js/data/planets.js
@@ -37,7 +37,7 @@ export const PLANET_TYPES = [
     radius: [0.5, 3]
   },
   {
-    name: 'gas giant',
+    name: 'gas',
     bias: 'outer',
     maxDistance: () => Infinity,
     radius: [4, 12]
@@ -51,7 +51,7 @@ export const PLANET_COLORS = {
   terrestrial: '#2ecc71',
   ice: '#87cefa',
   water: '#1e90ff',
-  'gas giant': '#f1c40f'
+  gas: '#f1c40f'
 };
 
 export const PLANET_FEATURES = [
@@ -75,7 +75,7 @@ export const PLANET_RESOURCES = {
   ],
   ice: ['water', 'methane', 'ammonia', 'nitrogen'],
   water: ['water', 'methane', 'ammonia', 'nitrogen'],
-  'gas giant': ['hydrogen', 'helium', 'methane', 'ammonia']
+  gas: ['hydrogen', 'helium', 'methane', 'ammonia']
 };
 
 export const PLANET_ATMOSPHERES = {
@@ -85,7 +85,7 @@ export const PLANET_ATMOSPHERES = {
   terrestrial: ['nitrogen', 'oxygen', 'argon'],
   ice: ['nitrogen', 'methane'],
   water: ['nitrogen', 'oxygen', 'water vapor'],
-  'gas giant': ['hydrogen', 'helium', 'methane', 'ammonia']
+  gas: ['hydrogen', 'helium', 'methane', 'ammonia']
 };
 
 // Rules for determining the maximum number of moons based on planet size

--- a/docs/js/data/stars.js
+++ b/docs/js/data/stars.js
@@ -16,7 +16,8 @@ export const STAR_TYPES = [
     mass: [16, 100],
     luminosity: [30000, 1000000],
     radius: [6.6, 15],
-    habitableZone: [100, 1000]
+    habitableZone: [100, 1000],
+    temperatureModifier: 1.8
   },
   {
     class: 'B',
@@ -25,7 +26,8 @@ export const STAR_TYPES = [
     mass: [2.1, 16],
     luminosity: [25, 30000],
     radius: [1.8, 6.6],
-    habitableZone: [5, 100]
+    habitableZone: [5, 100],
+    temperatureModifier: 1.5
   },
   {
     class: 'A',
@@ -34,7 +36,8 @@ export const STAR_TYPES = [
     mass: [1.4, 2.1],
     luminosity: [5, 25],
     radius: [1.4, 1.8],
-    habitableZone: [2, 5]
+    habitableZone: [2, 5],
+    temperatureModifier: 1.3
   },
   {
     class: 'F',
@@ -43,7 +46,8 @@ export const STAR_TYPES = [
     mass: [1.04, 1.4],
     luminosity: [1.5, 5],
     radius: [1.15, 1.4],
-    habitableZone: [1.3, 2.2]
+    habitableZone: [1.3, 2.2],
+    temperatureModifier: 1.1
   },
   {
     class: 'G',
@@ -52,7 +56,8 @@ export const STAR_TYPES = [
     mass: [0.8, 1.04],
     luminosity: [0.6, 1.5],
     radius: [0.9, 1.15],
-    habitableZone: [0.95, 1.4]
+    habitableZone: [0.95, 1.4],
+    temperatureModifier: 1
   },
   {
     class: 'K',
@@ -61,7 +66,8 @@ export const STAR_TYPES = [
     mass: [0.45, 0.8],
     luminosity: [0.08, 0.6],
     radius: [0.7, 0.96],
-    habitableZone: [0.38, 0.8]
+    habitableZone: [0.38, 0.8],
+    temperatureModifier: 0.9
   },
   {
     class: 'M',
@@ -70,6 +76,7 @@ export const STAR_TYPES = [
     mass: [0.08, 0.45],
     luminosity: [0.0001, 0.08],
     radius: [0.1, 0.7],
-    habitableZone: [0.02, 0.4]
+    habitableZone: [0.02, 0.4],
+    temperatureModifier: 0.8
   }
 ];

--- a/docs/js/star.js
+++ b/docs/js/star.js
@@ -19,7 +19,8 @@ export class Star extends StellarObject {
       luminosity: randomRange(type.luminosity[0], type.luminosity[1]),
       radius,
       gravity: randomRange(minGravity, maxGravity),
-      habitableZone: type.habitableZone
+      habitableZone: type.habitableZone,
+      temperatureModifier: type.temperatureModifier
     });
     this.planets = [];
     const planetCount = randomInt(0, 10);

--- a/docs/js/stellar-object.js
+++ b/docs/js/stellar-object.js
@@ -39,7 +39,13 @@ function interpolateSolarTemperature(distance) {
 }
 
 export function adjustPlanetType(type, temperature) {
-  if (type === 'ice' && temperature > 320) {
+  if (
+    temperature > 373 &&
+    (type === 'ice' || type === 'water')
+  ) {
+    return 'gas';
+  }
+  if (type === 'ice' && temperature > 273) {
     return 'water';
   }
   return type;
@@ -122,7 +128,7 @@ export function generateStellarObject(
   radius = Math.min(Math.max(radius, minR), maxR);
 
   let type = rule.name;
-  if (type === 'gas giant' && radius <= 4) {
+  if (type === 'gas' && radius <= 4) {
     type = 'ice';
   }
   if (radius < 0.3) {
@@ -131,7 +137,9 @@ export function generateStellarObject(
   }
 
   const baseTemperature =
-    interpolateSolarTemperature(distance) * Math.pow(star.luminosity, 0.25);
+    interpolateSolarTemperature(distance) *
+    Math.pow(star.luminosity, 0.25) *
+    (star.temperatureModifier || 1);
   const parentInfluence = parent ? (parent.gravity / step) * 10 : 0;
   const temperature = baseTemperature + parentInfluence;
   type = adjustPlanetType(type, temperature);
@@ -251,7 +259,7 @@ function selectRule(star, distance, prev) {
   });
   if (
     prev &&
-    prev.type === 'gas giant' &&
+    prev.type === 'gas' &&
     prev.radius > 6 &&
     Math.abs(distance - prev.distance) < 1
   ) {

--- a/docs/test/stellar-object.test.js
+++ b/docs/test/stellar-object.test.js
@@ -174,9 +174,14 @@ test('planet temperature span decreases with distance from star', () => {
   }
 });
 
-test('ice worlds above 320K become water type', () => {
-  assert.equal(adjustPlanetType('ice', 321), 'water');
-  assert.equal(adjustPlanetType('ice', 300), 'ice');
+test('ice and water transform based on temperature', () => {
+  // ice above 0°C becomes water
+  assert.equal(adjustPlanetType('ice', 274), 'water');
+  // ice or water above 100°C becomes gas
+  assert.equal(adjustPlanetType('ice', 374), 'gas');
+  assert.equal(adjustPlanetType('water', 400), 'gas');
+  // ice below freezing stays ice
+  assert.equal(adjustPlanetType('ice', 260), 'ice');
 });
 
 test('bases cannot orbit extremely hot objects', () => {


### PR DESCRIPTION
## Summary
- scale planet temperatures using a new `temperatureModifier` on each star type
- rename `gas giant` planet type to `gas`
- convert ice worlds to water above 0°C and to gas above 100°C with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892f3a8cbf0832ab86e0dbfc8e4b76e