### PR TITLE
Fix name generator import for tests

### DIFF
--- a/docs/js/name-generator.js
+++ b/docs/js/name-generator.js
@@ -4,11 +4,8 @@
 // Use the modern ES module build that ends with `.js` so that static servers
 // correctly set the `Content-Type` header. The previous `index.m.js` extension
 // caused the browser to block the module due to an empty MIME type.
-import {
-  uniqueNamesGenerator,
-  adjectives,
-  animals
-} from '../node_modules/unique-names-generator/dist/index.modern.js';
+import * as uniqueNamesGeneratorPkg from '../node_modules/unique-names-generator/dist/index.modern.js';
+const { uniqueNamesGenerator, adjectives, animals } = uniqueNamesGeneratorPkg;
 
 export function generateUniqueName() {
   return uniqueNamesGenerator({


### PR DESCRIPTION
## Summary
- import `unique-names-generator` using a namespace so its dictionaries can be accessed regardless of CommonJS or ESM semantics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68931de92b20832a9fc29fa4a9839b09