### PR TITLE
Render header before galaxy generation

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -17,7 +17,7 @@ function init() {
 
   const sidebar = createSidebar();
   let overview;
-  const galaxy = generateGalaxy();
+  let galaxy;
 
   function showGalaxy(selectedSystem = null) {
     const galaxyOverview = createGalaxyOverview(
@@ -93,9 +93,13 @@ function init() {
     setSidebarContent(sidebar, planetContent);
   }
 
-  showGalaxy();
   main.append(sidebar);
   app.append(header, main);
+
+  setTimeout(() => {
+    galaxy = generateGalaxy(100);
+    showGalaxy();
+  }, 0);
 }
 
 document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- Render header and sidebar before starting heavy galaxy generation.
- Generate the galaxy asynchronously with a smaller grid to avoid a blank screen on load.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689340758730832aa87ed62d4bb9de00