### PR TITLE
Add tests to ensure main components attach to DOM

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -8,7 +8,7 @@ import { createPlanetOverview } from './components/planet-overview.js';
 import { createBaseSidebar } from './components/base-sidebar.js';
 import { generateGalaxy } from './galaxy.js';
 
-function init() {
+export function init() {
   const app = document.getElementById('app');
 
   const header = createHeader('Guest', 'Explorer');

--- a/docs/test/main-dom.test.js
+++ b/docs/test/main-dom.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body><div id="app"></div></body></html>', {
+    pretendToBeVisual: true,
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.window.devicePixelRatio = 1;
+  dom.window.HTMLCanvasElement.prototype.getContext = () => ctxStub;
+  dom.window.HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    width: 300,
+    height: 300,
+    left: 0,
+    top: 0,
+  });
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      setTimeout(() => this.cb(), 0);
+    }
+    disconnect() {}
+  };
+  global.requestAnimationFrame = (fn) => setTimeout(fn, 0);
+}
+
+const ctxStub = {
+  setTransform() {},
+  fillRect() {},
+  beginPath() {},
+  arc() {},
+  fill() {},
+  stroke() {},
+  moveTo() {},
+  lineTo() {},
+  measureText: () => ({ width: 50 }),
+  fillText() {},
+};
+
+test('init attaches core components to DOM', async () => {
+  setupDom();
+  const { init } = await import('../js/main.js');
+  init();
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  const app = document.getElementById('app');
+  assert.ok(app.querySelector('#header'));
+  const main = app.querySelector('#main');
+  assert.ok(main);
+  assert.ok(main.querySelector('#sidebar'));
+  assert.ok(main.querySelector('.overview'));
+  delete global.window;
+  delete global.document;
+  delete global.ResizeObserver;
+  delete global.requestAnimationFrame;
+});


### PR DESCRIPTION
## Summary
- export `init` to simplify invocation in tests
- test that main initialization attaches header, sidebar, and overview elements

## Testing
- `cd docs && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893438328f0832abef3dadbd365b477