### PR TITLE
Ensure init runs after DOM is ready

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -101,5 +101,9 @@ export function init() {
     showGalaxy();
   }, 0);
 }
-
-document.addEventListener('DOMContentLoaded', init);
+// Ensure init runs even if DOMContentLoaded has already fired
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}


### PR DESCRIPTION
## Summary
- Ensure init executes even when DOMContentLoaded has already fired

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934baaeea0832a9f56c3019d3f152b