### PR TITLE
Reposition sidebar and show star info in system view

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -32,7 +32,7 @@ export function init() {
     if (overview) {
       main.replaceChild(galaxyOverview, overview);
     } else {
-      main.append(galaxyOverview);
+      main.insertBefore(galaxyOverview, sidebar);
     }
     overview = galaxyOverview;
 
@@ -63,11 +63,11 @@ export function init() {
     );
     main.replaceChild(systemView, overview);
     overview = systemView;
+    const starContent = createStarSidebar(system);
+    setSidebarContent(sidebar, starContent);
     if (selectedPlanet) {
       const planetContent = createPlanetSidebar(selectedPlanet);
       setSidebarContent(sidebar, planetContent);
-    } else {
-      clearSidebar(sidebar);
     }
   }
 
@@ -97,7 +97,7 @@ export function init() {
   app.append(header, main);
 
   setTimeout(() => {
-    galaxy = generateGalaxy(100);
+    galaxy = generateGalaxy(105);
     showGalaxy();
   }, 0);
 }

--- a/docs/less/sidebar.less
+++ b/docs/less/sidebar.less
@@ -1,5 +1,5 @@
 #sidebar {
-  width: 350px;
+  width: 400px;
   background: rgba(255, 255, 255, 0.05);
   padding: 1rem;
   border-left: 1px solid #444;


### PR DESCRIPTION
## Summary
- Move sidebar to the right and widen it for better visibility
- Display star information in the sidebar upon entering a star system
- Generate five additional stars in the galaxy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934e0656f4832ab0d088acca4bb81c