### PR TITLE
Expand galaxy star count and show habitable worlds

### DIFF
--- a/docs/js/components/galaxy-overview.js
+++ b/docs/js/components/galaxy-overview.js
@@ -16,6 +16,26 @@ export function createGalaxyOverview(
     system,
   }));
 
+  function countHabitable(bodies) {
+    return bodies.reduce((acc, body) => {
+      let total = acc;
+      if (body.isHabitable) total++;
+      if (body.moons?.length) {
+        total += countHabitable(body.moons);
+      }
+      return total;
+    }, 0);
+  }
+
+  const habitableWorldCount = galaxy.systems.reduce((count, { system }) => {
+    return (
+      count +
+      system.stars.reduce((starCount, star) => {
+        return starCount + countHabitable(star.planets || []);
+      }, 0)
+    );
+  }, 0);
+
   let starPositions = [];
   let hoveredIndex = null;
   let selectedIndex =
@@ -130,6 +150,11 @@ export function createGalaxyOverview(
   });
 
   overview.container.classList.add('galaxy-overview');
+
+  const habitableEl = document.createElement('div');
+  habitableEl.className = 'habitable-count';
+  habitableEl.textContent = `Habitable Worlds: ${habitableWorldCount}`;
+  overview.container.appendChild(habitableEl);
 
   canvas = overview.canvas;
   ctx = overview.ctx;

--- a/docs/js/galaxy.js
+++ b/docs/js/galaxy.js
@@ -5,8 +5,8 @@ export function generateStarSystem() {
   return { stars: [star], planets: star.planets };
 }
 
-// Default star formation chance reduced by a third to thin out the galaxy
-export function generateGalaxy(size = 500, chance = 0.001 * 2 / 3) {
+// Default star formation chance increased fivefold to expand the galaxy
+export function generateGalaxy(size = 500, chance = 0.001 * 10 / 3) {
   const systems = [];
   for (let x = -size; x <= size; x++) {
     for (let y = -size; y <= size; y++) {

--- a/docs/less/overview.less
+++ b/docs/less/overview.less
@@ -52,4 +52,14 @@
     font-size: 18px;
     pointer-events: none;
   }
+
+  .habitable-count {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: #fff;
+    font-size: 16px;
+    pointer-events: none;
+  }
 }

--- a/docs/test/galaxy-habitable-count.test.js
+++ b/docs/test/galaxy-habitable-count.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { createGalaxyOverview } from '../js/components/galaxy-overview.js';
+
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    pretendToBeVisual: true,
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.window.devicePixelRatio = 1;
+  dom.window.HTMLCanvasElement.prototype.getContext = () => ctxStub;
+  dom.window.HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    width: 300,
+    height: 300,
+    left: 0,
+    top: 0,
+  });
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      setTimeout(() => this.cb(), 0);
+    }
+    disconnect() {}
+  };
+  global.requestAnimationFrame = (fn) => setTimeout(fn, 0);
+}
+
+const ctxStub = {
+  setTransform() {},
+  fillRect() {},
+  beginPath() {},
+  arc() {},
+  fill() {},
+  stroke() {},
+  moveTo() {},
+  lineTo() {},
+  measureText: () => ({ width: 50 }),
+  fillText() {},
+};
+
+test('displays habitable world count', async () => {
+  setupDom();
+  const star = { name: 'TestStar', color: '#fff', planets: [{ isHabitable: true, moons: [] }] };
+  const galaxy = { size: 1, systems: [{ x: 0, y: 0, system: { stars: [star] } }] };
+
+  const overview = createGalaxyOverview(galaxy);
+  document.body.appendChild(overview);
+
+  await new Promise((r) => setTimeout(r, 0));
+
+  const countEl = overview.querySelector('.habitable-count');
+  assert.equal(countEl.textContent, 'Habitable Worlds: 1');
+
+  delete global.window;
+  delete global.document;
+  delete global.ResizeObserver;
+  delete global.requestAnimationFrame;
+});


### PR DESCRIPTION
## Summary
- Increase default star formation chance fivefold for denser galaxies
- Display total habitable worlds at the bottom of the galaxy overview
- Style and test the habitable world counter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935080ce98832a9aed8c21c09f6dbd