### PR TITLE
Exclude bases from habitable world count

### DIFF
--- a/docs/js/components/galaxy-overview.js
+++ b/docs/js/components/galaxy-overview.js
@@ -19,7 +19,7 @@ export function createGalaxyOverview(
   function countHabitable(bodies) {
     return bodies.reduce((acc, body) => {
       let total = acc;
-      if (body.isHabitable) total++;
+      if (body.isHabitable && body.kind !== 'base') total++;
       if (body.moons?.length) {
         total += countHabitable(body.moons);
       }

--- a/docs/test/galaxy-habitable-count.test.js
+++ b/docs/test/galaxy-habitable-count.test.js
@@ -45,7 +45,10 @@ const ctxStub = {
 
 test('displays habitable world count', async () => {
   setupDom();
-  const star = { name: 'TestStar', color: '#fff', planets: [{ isHabitable: true, moons: [] }] };
+  const habitableMoon = { isHabitable: true, kind: 'moon', moons: [] };
+  const base = { isHabitable: true, kind: 'base', moons: [] };
+  const planet = { isHabitable: true, kind: 'planet', moons: [habitableMoon, base] };
+  const star = { name: 'TestStar', color: '#fff', planets: [planet] };
   const galaxy = { size: 1, systems: [{ x: 0, y: 0, system: { stars: [star] } }] };
 
   const overview = createGalaxyOverview(galaxy);
@@ -54,7 +57,7 @@ test('displays habitable world count', async () => {
   await new Promise((r) => setTimeout(r, 0));
 
   const countEl = overview.querySelector('.habitable-count');
-  assert.equal(countEl.textContent, 'Habitable Worlds: 1');
+  assert.equal(countEl.textContent, 'Habitable Worlds: 2');
 
   delete global.window;
   delete global.document;


### PR DESCRIPTION
## Summary
- Ensure galaxy overview only counts planets and moons marked habitable
- Test galaxy overview excludes bases from habitable world count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689351df0b38832a9ea74bc458b7efdd