### PR TITLE
Move time controls to header

### DIFF
--- a/docs/js/components/galaxy-overview.js
+++ b/docs/js/components/galaxy-overview.js
@@ -147,7 +147,6 @@ export function createGalaxyOverview(
     update,
     draw,
     label: 'Galaxy',
-    showTime: false,
   });
 
   overview.container.classList.add('galaxy-overview');

--- a/docs/js/components/header.js
+++ b/docs/js/components/header.js
@@ -1,3 +1,11 @@
+import {
+  subscribe as subscribeTime,
+  play,
+  pause,
+  isPlaying,
+  getTime,
+} from '../time.js';
+
 export function createHeader(userName, playerName) {
   const header = document.createElement('header');
   header.id = 'header';
@@ -10,6 +18,47 @@ export function createHeader(userName, playerName) {
   playerInfo.className = 'player-info';
   playerInfo.textContent = `Player: ${playerName}`;
 
-  header.append(userInfo, playerInfo);
+  const infoContainer = document.createElement('div');
+  infoContainer.append(userInfo, playerInfo);
+
+  const controls = document.createElement('div');
+  controls.className = 'time-controls';
+
+  const display = document.createElement('span');
+  display.className = 'time-display';
+
+  const playBtn = document.createElement('button');
+  playBtn.textContent = '▶';
+
+  const pauseBtn = document.createElement('button');
+  pauseBtn.textContent = '⏸';
+
+  function updateDisplay(months) {
+    const year = Math.floor(months / 12);
+    const month = months % 12;
+    display.textContent = `${year}:${month}`;
+    playBtn.disabled = isPlaying();
+    pauseBtn.disabled = !isPlaying();
+  }
+
+  playBtn.addEventListener('click', () => {
+    play();
+    updateDisplay(getTime());
+  });
+  pauseBtn.addEventListener('click', () => {
+    pause();
+    updateDisplay(getTime());
+  });
+
+  controls.append(display, playBtn, pauseBtn);
+  const unsubscribe = subscribeTime(updateDisplay);
+  updateDisplay(getTime());
+
+  header.append(infoContainer, controls);
+
+  header.destroy = () => {
+    unsubscribe();
+  };
+
   return header;
 }

--- a/docs/js/components/overview.js
+++ b/docs/js/components/overview.js
@@ -1,12 +1,4 @@
-import {
-  subscribe as subscribeTime,
-  play,
-  pause,
-  isPlaying,
-  getTime,
-} from '../time.js';
-
-export function createOverview({ update, draw, label, showTime = true } = {}) {
+export function createOverview({ update, draw, label } = {}) {
   const container = document.createElement('div');
   container.className = 'overview';
 
@@ -59,48 +51,6 @@ export function createOverview({ update, draw, label, showTime = true } = {}) {
   const resizeObserver = new ResizeObserver(resize);
   resizeObserver.observe(canvas);
 
-  let unsubscribeTime = null;
-  if (showTime) {
-    const controls = document.createElement('div');
-    controls.className = 'time-controls';
-
-    const display = document.createElement('span');
-    display.className = 'time-display';
-
-    const playBtn = document.createElement('button');
-    playBtn.textContent = '▶';
-
-    const pauseBtn = document.createElement('button');
-    pauseBtn.textContent = '⏸';
-
-    function updateDisplay(months) {
-      const year = Math.floor(months / 12);
-      const month = months % 12;
-      display.textContent = `${year}:${month}`;
-      playBtn.disabled = isPlaying();
-      pauseBtn.disabled = !isPlaying();
-    }
-
-    playBtn.addEventListener('click', () => {
-      play();
-      updateDisplay(getTime());
-    });
-    pauseBtn.addEventListener('click', () => {
-      pause();
-      updateDisplay(getTime());
-    });
-
-    controls.append(display, playBtn, pauseBtn);
-    container.appendChild(controls);
-
-    unsubscribeTime = subscribeTime((months) => {
-      updateDisplay(months);
-      if (typeof update === 'function') update(zoom);
-      if (typeof draw === 'function') draw(zoom);
-    });
-    updateDisplay(getTime());
-  }
-
   requestAnimationFrame(resize);
 
   const renderInterval = setInterval(() => {
@@ -115,7 +65,6 @@ export function createOverview({ update, draw, label, showTime = true } = {}) {
     destroyed = true;
     resizeObserver.disconnect();
     clearInterval(renderInterval);
-    if (unsubscribeTime) unsubscribeTime();
   }
 
   container.destroy = destroy;

--- a/docs/less/header.less
+++ b/docs/less/header.less
@@ -8,7 +8,22 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 
-.user-info,
-.player-info {
+.user-info {
   margin-right: 1rem;
+}
+
+.time-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .time-display {
+    min-width: 50px;
+    text-align: center;
+  }
+
+  button {
+    width: 40px;
+    height: 40px;
+  }
 }

--- a/docs/less/overview.less
+++ b/docs/less/overview.less
@@ -63,23 +63,4 @@
     pointer-events: none;
   }
 
-  .time-controls {
-    position: absolute;
-    bottom: 8px;
-    right: 8px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    color: #fff;
-
-    .time-display {
-      min-width: 50px;
-      text-align: center;
-    }
-
-    button {
-      width: 40px;
-      height: 40px;
-    }
-  }
 }

--- a/docs/test/main-dom.test.js
+++ b/docs/test/main-dom.test.js
@@ -48,11 +48,15 @@ test('init attaches core components to DOM', async () => {
   await new Promise((r) => setTimeout(r, 0));
   await new Promise((r) => setTimeout(r, 0));
   const app = document.getElementById('app');
-  assert.ok(app.querySelector('#header'));
+  const header = app.querySelector('#header');
+  assert.ok(header);
+  assert.ok(header.querySelector('.time-controls'));
   const main = app.querySelector('#main');
   assert.ok(main);
   assert.ok(main.querySelector('#sidebar'));
-  assert.ok(main.querySelector('.overview'));
+  const overview = main.querySelector('.overview');
+  assert.ok(overview);
+  assert.equal(overview.querySelector('.time-controls'), null);
   delete global.window;
   delete global.document;
   delete global.ResizeObserver;


### PR DESCRIPTION
## Summary
- Show current time and play/pause controls in the header for global visibility
- Remove per-overview time UI and related styling
- Update tests to reflect new header-based time controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68936bb60f7c832abca6bbb79f5d7f01