### PR TITLE
Expand orbital and planetary facilities and shrink object renders

### DIFF
--- a/docs/js/components/galaxy-overview.js
+++ b/docs/js/components/galaxy-overview.js
@@ -6,7 +6,7 @@ export function createGalaxyOverview(
   onOpenSystem,
   selectedSystem = null
 ) {
-  const STAR_RADIUS = 12;
+  const STAR_RADIUS = 6;
   const size = galaxy.size;
 
   const systems = galaxy.systems.map(({ x, y, system }) => ({
@@ -161,6 +161,7 @@ export function createGalaxyOverview(
 
   function getStarIndex(event) {
     const rect = canvas.getBoundingClientRect();
+    if (canvas.width === 0 || rect.width === 0) return -1;
     const scale = canvas.width / rect.width;
     const x = (event.clientX - rect.left) * scale;
     const y = (event.clientY - rect.top) * scale;

--- a/docs/js/components/planet-overview.js
+++ b/docs/js/components/planet-overview.js
@@ -1,4 +1,4 @@
-import { PLANET_COLORS } from '../data/planets.js';
+import { PLANET_COLORS, ORBITAL_FACILITIES } from '../data/planets.js';
 import { createOverview } from './overview.js';
 import { getMoonTime } from '../time.js';
 
@@ -10,14 +10,98 @@ export function createPlanetOverview(
   height = 400
 ) {
   const objects = planet.moons || [];
-  const PLANET_RADIUS = 40; // constant radius for planet
-  const OBJECT_RADIUS = 16; // constant radius for moons and bases
+  const PLANET_RADIUS = 20; // constant radius for planet
+  const OBJECT_RADIUS = 8; // constant radius for moons and bases
+  const ICON_SIZE = 4;
+  const BASE_ICON_SIZE = 8 / 6;
+  const MOON_ICON_RADIUS = 2;
+  const ORBITAL_COLOR = '#0ff';
+  const PLANETARY_COLOR = '#ff0';
 
   let planetRadius = PLANET_RADIUS;
   let objectData = [];
   let hoveredIndex = null;
   let canvas;
   let ctx;
+
+  function drawFeatureIcon(ctx, feature, x, y) {
+    ctx.lineWidth = 1;
+    const orbital = ORBITAL_FACILITIES.includes(feature);
+    ctx.fillStyle = orbital ? ORBITAL_COLOR : PLANETARY_COLOR;
+    ctx.strokeStyle = ctx.fillStyle;
+    let size = ICON_SIZE;
+    switch (feature) {
+      case 'base':
+        size = BASE_ICON_SIZE;
+        ctx.fillRect(x, y - size / 2, size, size);
+        break;
+      case 'shipyard':
+        ctx.fillRect(x - size / 2, y - size / 2, size, size);
+        ctx.fillRect(x - size / 6, y - size, size / 3, size / 2);
+        break;
+      case 'orbitalMine':
+        ctx.beginPath();
+        ctx.moveTo(x, y + size / 2);
+        ctx.lineTo(x + size / 2, y - size / 2);
+        ctx.lineTo(x - size / 2, y - size / 2);
+        ctx.closePath();
+        ctx.fill();
+        break;
+      case 'orbitalManufactory':
+        ctx.beginPath();
+        ctx.moveTo(x, y - size / 2);
+        ctx.lineTo(x + size / 2, y);
+        ctx.lineTo(x, y + size / 2);
+        ctx.lineTo(x - size / 2, y);
+        ctx.closePath();
+        ctx.fill();
+        break;
+      case 'orbitalResearch':
+        ctx.beginPath();
+        ctx.arc(x, y, size / 2, 0, Math.PI * 2);
+        ctx.fill();
+        break;
+      case 'jumpStation':
+        ctx.fillRect(x - size / 6, y - size / 2, size / 3, size);
+        ctx.fillRect(x - size / 2, y - size / 6, size, size / 3);
+        break;
+      case 'mine':
+        ctx.beginPath();
+        ctx.moveTo(x - size / 2, y - size / 2);
+        ctx.lineTo(x + size / 2, y - size / 2);
+        ctx.lineTo(x, y + size / 2);
+        ctx.closePath();
+        ctx.fill();
+        break;
+      case 'spaceport':
+        ctx.beginPath();
+        ctx.moveTo(x, y - size / 2);
+        ctx.lineTo(x + size / 2, y);
+        ctx.lineTo(x, y + size / 2);
+        ctx.lineTo(x - size / 2, y);
+        ctx.closePath();
+        ctx.fill();
+        break;
+      case 'manufactory':
+        ctx.fillRect(x - size / 2, y - size / 2, size, size);
+        ctx.beginPath();
+        ctx.moveTo(x - size / 2, y);
+        ctx.lineTo(x + size / 2, y);
+        ctx.moveTo(x, y - size / 2);
+        ctx.lineTo(x, y + size / 2);
+        ctx.stroke();
+        break;
+      case 'research':
+        ctx.beginPath();
+        ctx.moveTo(x - size / 2, y - size / 2);
+        ctx.lineTo(x + size / 2, y + size / 2);
+        ctx.moveTo(x + size / 2, y - size / 2);
+        ctx.lineTo(x - size / 2, y + size / 2);
+        ctx.stroke();
+        break;
+    }
+    return feature === 'base' ? BASE_ICON_SIZE : ICON_SIZE;
+  }
 
   function updateLayout(zoom) {
     const cx = canvas.width / 2;
@@ -92,27 +176,18 @@ export function createPlanetOverview(
     ctx.arc(cx, cy, planetRadius, 0, Math.PI * 2);
     ctx.fill();
 
-    let iconX = cx + planetRadius + 8;
+    let iconX = cx + planetRadius + ICON_SIZE;
     const iconY = cy;
     if (planet.features) {
-      planet.features
-        .filter((f) => f !== 'base')
-        .forEach((f) => {
-          ctx.fillStyle = '#fff';
-          if (f === 'mine') {
-            ctx.beginPath();
-            ctx.moveTo(iconX, iconY - 6);
-            ctx.lineTo(iconX + 8, iconY - 6);
-            ctx.lineTo(iconX + 4, iconY + 2);
-            ctx.fill();
-          }
-          iconX += 12;
-        });
+      planet.features.forEach((f) => {
+        const size = drawFeatureIcon(ctx, f, iconX, iconY);
+        iconX += size + 4;
+      });
     }
     if (planet.moons && planet.moons.length) {
       ctx.beginPath();
       ctx.fillStyle = '#fff';
-      ctx.arc(iconX + 4, iconY, 4, 0, Math.PI * 2);
+      ctx.arc(iconX + MOON_ICON_RADIUS, iconY, MOON_ICON_RADIUS, 0, Math.PI * 2);
       ctx.fill();
     }
 

--- a/docs/js/components/system-overview.js
+++ b/docs/js/components/system-overview.js
@@ -1,4 +1,4 @@
-import { PLANET_COLORS } from '../data/planets.js';
+import { PLANET_COLORS, ORBITAL_FACILITIES } from '../data/planets.js';
 import { createOverview } from './overview.js';
 import { getPlanetTime } from '../time.js';
 
@@ -14,8 +14,13 @@ export function createSystemOverview(
 ) {
   const star = system.stars[0];
   const planets = system.planets;
-  const STAR_SCALE = 12;
-  const PLANET_RADIUS = 16; // constant radius for all planets
+  const STAR_SCALE = 6;
+  const PLANET_RADIUS = 8; // constant radius for all planets
+  const ICON_SIZE = 4;
+  const BASE_ICON_SIZE = 8 / 6;
+  const MOON_ICON_RADIUS = 2;
+  const ORBITAL_COLOR = '#0ff';
+  const PLANETARY_COLOR = '#ff0';
 
   const baseStarRadius = star.size * 2 * STAR_SCALE;
   const basePlanetRadius = PLANET_RADIUS;
@@ -27,6 +32,85 @@ export function createSystemOverview(
     selectedPlanet ? planets.findIndex((p) => p === selectedPlanet) : null;
   let canvas;
   let ctx;
+
+  function drawFeatureIcon(ctx, feature, x, y) {
+    ctx.lineWidth = 1;
+    const orbital = ORBITAL_FACILITIES.includes(feature);
+    ctx.fillStyle = orbital ? ORBITAL_COLOR : PLANETARY_COLOR;
+    ctx.strokeStyle = ctx.fillStyle;
+    let size = ICON_SIZE;
+    switch (feature) {
+      case 'base':
+        size = BASE_ICON_SIZE;
+        ctx.fillRect(x, y - size / 2, size, size);
+        break;
+      case 'shipyard':
+        ctx.fillRect(x - size / 2, y - size / 2, size, size);
+        ctx.fillRect(x - size / 6, y - size, size / 3, size / 2);
+        break;
+      case 'orbitalMine':
+        ctx.beginPath();
+        ctx.moveTo(x, y + size / 2);
+        ctx.lineTo(x + size / 2, y - size / 2);
+        ctx.lineTo(x - size / 2, y - size / 2);
+        ctx.closePath();
+        ctx.fill();
+        break;
+      case 'orbitalManufactory':
+        ctx.beginPath();
+        ctx.moveTo(x, y - size / 2);
+        ctx.lineTo(x + size / 2, y);
+        ctx.lineTo(x, y + size / 2);
+        ctx.lineTo(x - size / 2, y);
+        ctx.closePath();
+        ctx.fill();
+        break;
+      case 'orbitalResearch':
+        ctx.beginPath();
+        ctx.arc(x, y, size / 2, 0, Math.PI * 2);
+        ctx.fill();
+        break;
+      case 'jumpStation':
+        ctx.fillRect(x - size / 6, y - size / 2, size / 3, size);
+        ctx.fillRect(x - size / 2, y - size / 6, size, size / 3);
+        break;
+      case 'mine':
+        ctx.beginPath();
+        ctx.moveTo(x - size / 2, y - size / 2);
+        ctx.lineTo(x + size / 2, y - size / 2);
+        ctx.lineTo(x, y + size / 2);
+        ctx.closePath();
+        ctx.fill();
+        break;
+      case 'spaceport':
+        ctx.beginPath();
+        ctx.moveTo(x, y - size / 2);
+        ctx.lineTo(x + size / 2, y);
+        ctx.lineTo(x, y + size / 2);
+        ctx.lineTo(x - size / 2, y);
+        ctx.closePath();
+        ctx.fill();
+        break;
+      case 'manufactory':
+        ctx.fillRect(x - size / 2, y - size / 2, size, size);
+        ctx.beginPath();
+        ctx.moveTo(x - size / 2, y);
+        ctx.lineTo(x + size / 2, y);
+        ctx.moveTo(x, y - size / 2);
+        ctx.lineTo(x, y + size / 2);
+        ctx.stroke();
+        break;
+      case 'research':
+        ctx.beginPath();
+        ctx.moveTo(x - size / 2, y - size / 2);
+        ctx.lineTo(x + size / 2, y + size / 2);
+        ctx.moveTo(x + size / 2, y - size / 2);
+        ctx.lineTo(x - size / 2, y + size / 2);
+        ctx.stroke();
+        break;
+    }
+    return feature === 'base' ? BASE_ICON_SIZE : ICON_SIZE;
+  }
 
   function updateLayout(zoom) {
     const cx = canvas.width / 2;
@@ -89,27 +173,18 @@ export function createSystemOverview(
       ctx.arc(px, py, planetRadius, 0, Math.PI * 2);
       ctx.fill();
 
-      let iconX = px + planetRadius + 8;
+      let iconX = px + planetRadius + ICON_SIZE;
       const iconY = py;
       if (planet.features) {
         planet.features.forEach((f) => {
-          ctx.fillStyle = '#fff';
-          if (f === 'base') {
-            ctx.fillRect(iconX, iconY - 4, 8, 8);
-          } else if (f === 'mine') {
-            ctx.beginPath();
-            ctx.moveTo(iconX, iconY - 6);
-            ctx.lineTo(iconX + 8, iconY - 6);
-            ctx.lineTo(iconX + 4, iconY + 2);
-            ctx.fill();
-          }
-          iconX += 12;
+          const size = drawFeatureIcon(ctx, f, iconX, iconY);
+          iconX += size + 4;
         });
       }
       if (planet.moons && planet.moons.length) {
         ctx.beginPath();
         ctx.fillStyle = '#fff';
-        ctx.arc(iconX + 4, iconY, 4, 0, Math.PI * 2);
+        ctx.arc(iconX + MOON_ICON_RADIUS, iconY, MOON_ICON_RADIUS, 0, Math.PI * 2);
         ctx.fill();
       }
 

--- a/docs/js/data/planets.js
+++ b/docs/js/data/planets.js
@@ -55,9 +55,30 @@ export const PLANET_COLORS = {
 };
 
 export const PLANET_FEATURES = [
-  { name: 'base', chance: 0.1 },
-  { name: 'mine', chance: 0.1 }
+  { name: 'base', chance: 0.1, category: 'orbital' },
+  { name: 'shipyard', chance: 0.1, category: 'orbital' },
+  {
+    name: 'orbitalMine',
+    chance: 0.1,
+    category: 'orbital',
+    condition: (body) => body.type === 'gas'
+  },
+  { name: 'orbitalManufactory', chance: 0.1, category: 'orbital' },
+  { name: 'orbitalResearch', chance: 0.1, category: 'orbital' },
+  { name: 'jumpStation', chance: 0.1, category: 'orbital' },
+  { name: 'mine', chance: 0.1, category: 'planetary' },
+  { name: 'spaceport', chance: 0.1, category: 'planetary' },
+  { name: 'manufactory', chance: 0.1, category: 'planetary' },
+  { name: 'research', chance: 0.1, category: 'planetary' }
 ];
+
+export const ORBITAL_FACILITIES = PLANET_FEATURES.filter(
+  (f) => f.category === 'orbital'
+).map((f) => f.name);
+
+export const PLANETARY_FACILITIES = PLANET_FEATURES.filter(
+  (f) => f.category === 'planetary'
+).map((f) => f.name);
 
 export const PLANET_RESOURCES = {
   rocky: ['iron', 'cobalt', 'uranium', 'carbon', 'silicon', 'nickel', 'water'],

--- a/docs/js/objects/orbiting-body.js
+++ b/docs/js/objects/orbiting-body.js
@@ -76,9 +76,17 @@ export class OrbitingBody extends StellarObject {
       star,
       parent
     );
-    const features = PLANET_FEATURES.filter((f) => Math.random() < f.chance).map(
-      (f) => f.name
-    );
+    const features = PLANET_FEATURES.filter((f) => {
+      if (f.category === 'planetary') {
+        if (type === 'gas' || temperature >= 200 || gravity >= 1.5) {
+          return false;
+        }
+      }
+      if (f.name === 'orbitalMine' && type !== 'gas') {
+        return false;
+      }
+      return Math.random() < f.chance;
+    }).map((f) => f.name);
     const angle = Math.random() * Math.PI * 2;
     const eccentricity = Math.random() ** 2 * 0.6;
     const orbitRotation = Math.random() * Math.PI * 2;


### PR DESCRIPTION
## Summary
- Halve rendering scale for stars, planets, moons and adjust galaxy overview to match
- Add new orbital and planetary facilities with distinct icons and color schemes
- Restrict facility generation by environment and allow orbital mine only around gas giants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893944add54832a9936340e22eed4b3