### PR TITLE
Fix orbital facility orbits and planet overview display

### DIFF
--- a/docs/js/components/planet-overview.js
+++ b/docs/js/components/planet-overview.js
@@ -1,4 +1,4 @@
-import { PLANET_COLORS, ORBITAL_FACILITIES } from '../data/planets.js';
+import { PLANET_COLORS } from '../data/planets.js';
 import { createOverview } from './overview.js';
 import { getMoonTime } from '../time.js';
 
@@ -12,96 +12,12 @@ export function createPlanetOverview(
   const objects = planet.moons || [];
   const PLANET_RADIUS = 20; // constant radius for planet
   const OBJECT_RADIUS = 8; // constant radius for moons and bases
-  const ICON_SIZE = 4;
-  const BASE_ICON_SIZE = 8 / 6;
-  const MOON_ICON_RADIUS = 2;
-  const ORBITAL_COLOR = '#0ff';
-  const SURFACE_COLOR = '#ff0';
 
   let planetRadius = PLANET_RADIUS;
   let objectData = [];
   let hoveredIndex = null;
   let canvas;
   let ctx;
-
-  function drawFeatureIcon(ctx, feature, x, y) {
-    ctx.lineWidth = 1;
-    const orbital = ORBITAL_FACILITIES.includes(feature);
-    ctx.fillStyle = orbital ? ORBITAL_COLOR : SURFACE_COLOR;
-    ctx.strokeStyle = ctx.fillStyle;
-    let size = ICON_SIZE;
-    switch (feature) {
-      case 'base':
-        size = BASE_ICON_SIZE;
-        ctx.fillRect(x, y - size / 2, size, size);
-        break;
-      case 'shipyard':
-        ctx.fillRect(x - size / 2, y - size / 2, size, size);
-        ctx.fillRect(x - size / 6, y - size, size / 3, size / 2);
-        break;
-      case 'orbitalMine':
-        ctx.beginPath();
-        ctx.moveTo(x, y + size / 2);
-        ctx.lineTo(x + size / 2, y - size / 2);
-        ctx.lineTo(x - size / 2, y - size / 2);
-        ctx.closePath();
-        ctx.fill();
-        break;
-      case 'orbitalManufactory':
-        ctx.beginPath();
-        ctx.moveTo(x, y - size / 2);
-        ctx.lineTo(x + size / 2, y);
-        ctx.lineTo(x, y + size / 2);
-        ctx.lineTo(x - size / 2, y);
-        ctx.closePath();
-        ctx.fill();
-        break;
-      case 'orbitalResearch':
-        ctx.beginPath();
-        ctx.arc(x, y, size / 2, 0, Math.PI * 2);
-        ctx.fill();
-        break;
-      case 'jumpStation':
-        ctx.fillRect(x - size / 6, y - size / 2, size / 3, size);
-        ctx.fillRect(x - size / 2, y - size / 6, size, size / 3);
-        break;
-      case 'mine':
-        ctx.beginPath();
-        ctx.moveTo(x - size / 2, y - size / 2);
-        ctx.lineTo(x + size / 2, y - size / 2);
-        ctx.lineTo(x, y + size / 2);
-        ctx.closePath();
-        ctx.fill();
-        break;
-      case 'spaceport':
-        ctx.beginPath();
-        ctx.moveTo(x, y - size / 2);
-        ctx.lineTo(x + size / 2, y);
-        ctx.lineTo(x, y + size / 2);
-        ctx.lineTo(x - size / 2, y);
-        ctx.closePath();
-        ctx.fill();
-        break;
-      case 'manufactory':
-        ctx.fillRect(x - size / 2, y - size / 2, size, size);
-        ctx.beginPath();
-        ctx.moveTo(x - size / 2, y);
-        ctx.lineTo(x + size / 2, y);
-        ctx.moveTo(x, y - size / 2);
-        ctx.lineTo(x, y + size / 2);
-        ctx.stroke();
-        break;
-      case 'research':
-        ctx.beginPath();
-        ctx.moveTo(x - size / 2, y - size / 2);
-        ctx.lineTo(x + size / 2, y + size / 2);
-        ctx.moveTo(x + size / 2, y - size / 2);
-        ctx.lineTo(x - size / 2, y + size / 2);
-        ctx.stroke();
-        break;
-    }
-    return feature === 'base' ? BASE_ICON_SIZE : ICON_SIZE;
-  }
 
   function updateLayout(zoom) {
     const cx = canvas.width / 2;
@@ -175,21 +91,6 @@ export function createPlanetOverview(
     ctx.fillStyle = PLANET_COLORS[planet.type] || '#fff';
     ctx.arc(cx, cy, planetRadius, 0, Math.PI * 2);
     ctx.fill();
-
-    let iconX = cx + planetRadius + ICON_SIZE;
-    const iconY = cy;
-    if (planet.features) {
-      planet.features.forEach((f) => {
-        const size = drawFeatureIcon(ctx, f, iconX, iconY);
-        iconX += size + 4;
-      });
-    }
-    if (planet.moons && planet.moons.length) {
-      ctx.beginPath();
-      ctx.fillStyle = '#fff';
-      ctx.arc(iconX + MOON_ICON_RADIUS, iconY, MOON_ICON_RADIUS, 0, Math.PI * 2);
-      ctx.fill();
-    }
 
     ctx.fillStyle = '#fff';
     ctx.textAlign = 'center';

--- a/docs/js/facilities/facility.js
+++ b/docs/js/facilities/facility.js
@@ -1,4 +1,4 @@
-import { StellarObject, randomRange } from '../objects/util.js';
+import { StellarObject, randomRange, EARTH_MASS_IN_SOLAR } from '../objects/util.js';
 
 export class Facility extends StellarObject {}
 
@@ -10,6 +10,10 @@ export class OrbitalFacility extends Facility {
     const angle = Math.random() * Math.PI * 2;
     const eccentricity = Math.random() * 0.01;
     const orbitRotation = Math.random() * Math.PI * 2;
+    const parentMassInSolar = parent.mass * EARTH_MASS_IN_SOLAR;
+    const orbitalPeriod = Math.sqrt(
+      Math.pow(orbitDistance, 3) / parentMassInSolar
+    );
     const baseName = this.kind
       ? this.kind.charAt(0).toUpperCase() + this.kind.slice(1)
       : 'Facility';
@@ -24,7 +28,7 @@ export class OrbitalFacility extends Facility {
       temperature: parent.temperature,
       temperatureSpan: parent.temperatureSpan,
       isHabitable: true,
-      orbitalPeriod: Math.sqrt(Math.pow(distance, 3) / star.mass),
+      orbitalPeriod,
       features: [],
       angle,
       eccentricity,

--- a/docs/js/stellar-object.js
+++ b/docs/js/stellar-object.js
@@ -12,8 +12,7 @@ import {
   Shipyard,
   OrbitalMine,
   OrbitalManufactory,
-  OrbitalResearch,
-  JumpStation
+  OrbitalResearch
 } from './facilities/index.js';
 
 const generators = {
@@ -23,8 +22,7 @@ const generators = {
   shipyard: Shipyard,
   orbitalMine: OrbitalMine,
   orbitalManufactory: OrbitalManufactory,
-  orbitalResearch: OrbitalResearch,
-  jumpStation: JumpStation
+  orbitalResearch: OrbitalResearch
 };
 
 export { ATMOSPHERE_GRAVITY_THRESHOLD, randomInt, randomRange, adjustPlanetType, StellarObject };


### PR DESCRIPTION
## Summary
- Remove jump stations from generic stellar object generation so they're only orbital facilities
- Compute orbital facility orbital periods using parent mass like moons
- Stop drawing moon and facility icons in the planet overview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68939dc50be8832a9afd67df42762a27