### PR TITLE
Reduce overview scales and tweak facility stats

### DIFF
--- a/docs/js/components/galaxy-overview.js
+++ b/docs/js/components/galaxy-overview.js
@@ -1,4 +1,5 @@
 import { createOverview } from './overview.js';
+import { ORBITAL_FACILITIES } from '../data/planets.js';
 
 export function createGalaxyOverview(
   galaxy,
@@ -19,7 +20,7 @@ export function createGalaxyOverview(
   function countHabitable(bodies) {
     return bodies.reduce((acc, body) => {
       let total = acc;
-      if (body.isHabitable && body.kind !== 'base') total++;
+      if (body.isHabitable && !ORBITAL_FACILITIES.includes(body.kind)) total++;
       if (body.moons?.length) {
         total += countHabitable(body.moons);
       }
@@ -44,6 +45,7 @@ export function createGalaxyOverview(
   let ctx;
 
   function update(zoom) {
+    if (canvas.width === 0 || canvas.height === 0) return;
     const scale =
       (Math.min(canvas.width, canvas.height) / (size * 2 + 1)) * zoom;
     const offsetX = (canvas.width - scale * (size * 2 + 1)) / 2;

--- a/docs/js/components/planet-overview.js
+++ b/docs/js/components/planet-overview.js
@@ -10,8 +10,8 @@ export function createPlanetOverview(
   height = 400
 ) {
   const objects = planet.moons || [];
-  const PLANET_RADIUS = 20; // constant radius for planet
-  const OBJECT_RADIUS = 8; // constant radius for moons and bases
+  const PLANET_RADIUS = 10; // constant radius for planet
+  const OBJECT_RADIUS = 4; // constant radius for moons and bases
 
   let planetRadius = PLANET_RADIUS;
   let objectData = [];

--- a/docs/js/components/system-overview.js
+++ b/docs/js/components/system-overview.js
@@ -14,8 +14,8 @@ export function createSystemOverview(
 ) {
   const star = system.stars[0];
   const planets = system.planets;
-  const STAR_SCALE = 6;
-  const PLANET_RADIUS = 8; // constant radius for all planets
+  const STAR_SCALE = 3;
+  const PLANET_RADIUS = 4; // constant radius for all planets
   const ICON_SIZE = 4;
   const BASE_ICON_SIZE = 8 / 6;
   const MOON_ICON_RADIUS = 2;

--- a/docs/js/facilities/facility.js
+++ b/docs/js/facilities/facility.js
@@ -5,7 +5,7 @@ export class Facility extends StellarObject {}
 export class OrbitalFacility extends Facility {
   static generate(star, orbitIndex, parent) {
     if (parent.temperature > 400) return null;
-    const orbitDistance = (orbitIndex + 1) * randomRange(0.001, 0.01);
+    const orbitDistance = (orbitIndex + 1) * randomRange(0.002, 0.02);
     const distance = parent.distance + orbitDistance;
     const angle = Math.random() * Math.PI * 2;
     const eccentricity = Math.random() * 0.01;
@@ -24,9 +24,9 @@ export class OrbitalFacility extends Facility {
       distance,
       orbitDistance,
       radius: 0.05,
-      gravity: parent.gravity,
-      temperature: parent.temperature,
-      temperatureSpan: parent.temperatureSpan,
+      gravity: 0,
+      temperature: 293,
+      temperatureSpan: 0,
       isHabitable: true,
       orbitalPeriod,
       features: [],
@@ -35,7 +35,7 @@ export class OrbitalFacility extends Facility {
       orbitRotation,
       resources: {},
       atmosphere: null,
-      atmosphericPressure: 0,
+      atmosphericPressure: 1,
       moons: [],
       population: Math.floor(randomRange(100, 1000))
     });

--- a/docs/test/galaxy-habitable-count.test.js
+++ b/docs/test/galaxy-habitable-count.test.js
@@ -47,7 +47,12 @@ test('displays habitable world count', async () => {
   setupDom();
   const habitableMoon = { isHabitable: true, kind: 'moon', moons: [] };
   const base = { isHabitable: true, kind: 'base', moons: [] };
-  const planet = { isHabitable: true, kind: 'planet', moons: [habitableMoon, base] };
+  const shipyard = { isHabitable: true, kind: 'shipyard', moons: [] };
+  const planet = {
+    isHabitable: true,
+    kind: 'planet',
+    moons: [habitableMoon, base, shipyard],
+  };
   const star = { name: 'TestStar', color: '#fff', planets: [planet] };
   const galaxy = { size: 1, systems: [{ x: 0, y: 0, system: { stars: [star] } }] };
 

--- a/docs/test/galaxy-hover.test.js
+++ b/docs/test/galaxy-hover.test.js
@@ -88,6 +88,7 @@ test('moving over empty space does not crash', async () => {
   document.body.appendChild(overview);
 
   await new Promise((r) => setTimeout(r, 0));
+  capturedText = null;
 
   const canvas = overview.querySelector('canvas');
   const event = new window.MouseEvent('mousemove', {

--- a/docs/test/stellar-object.test.js
+++ b/docs/test/stellar-object.test.js
@@ -33,15 +33,10 @@ function validateBody(body, star, parent = null) {
   if (ORBITAL_FACILITIES.includes(body.type)) {
     assert.ok(body.distance > 0);
     assert.ok(typeof body.radius === 'number');
-    assert.ok(typeof body.gravity === 'number');
-    assert.ok(typeof body.atmosphericPressure === 'number');
-    assert.ok(typeof body.temperatureSpan === 'number');
-    assert.equal(body.atmosphericPressure, 0);
-    if (parent) {
-      assert.equal(body.gravity, parent.gravity);
-      assert.equal(body.temperature, parent.temperature);
-      assert.equal(body.temperatureSpan, parent.temperatureSpan);
-    }
+    assert.equal(body.gravity, 0);
+    assert.equal(body.atmosphericPressure, 1);
+    assert.equal(body.temperatureSpan, 0);
+    assert.equal(body.temperature, 293);
     return;
   }
   assert.ok(typeof body.gravity === 'number');


### PR DESCRIPTION
## Summary
- shrink planets, moons, and stars in system/planet overviews
- push orbital facilities farther out and set zero-G, Earth-pressure, 20 °C defaults
- ignore orbital facilities when counting habitable worlds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893a37677ac832ab7d9f9d1e5113296