### PR TITLE
refactor: extract habitable world counter

### DIFF
--- a/docs/js/components/galaxy-overview.js
+++ b/docs/js/components/galaxy-overview.js
@@ -1,5 +1,5 @@
 import { createOverview } from './overview.js';
-import { ORBITAL_FACILITIES } from '../data/planets.js';
+import { countHabitableWorlds } from '../utils/habitable-worlds.js';
 
 export function createGalaxyOverview(
   galaxy,
@@ -17,25 +17,7 @@ export function createGalaxyOverview(
     system,
   }));
 
-  function countHabitable(bodies) {
-    return bodies.reduce((acc, body) => {
-      let total = acc;
-      if (body.isHabitable && !ORBITAL_FACILITIES.includes(body.kind)) total++;
-      if (body.moons?.length) {
-        total += countHabitable(body.moons);
-      }
-      return total;
-    }, 0);
-  }
-
-  const habitableWorldCount = galaxy.systems.reduce((count, { system }) => {
-    return (
-      count +
-      system.stars.reduce((starCount, star) => {
-        return starCount + countHabitable(star.planets || []);
-      }, 0)
-    );
-  }, 0);
+  const habitableWorldCount = countHabitableWorlds(galaxy);
 
   let starPositions = [];
   let hoveredIndex = null;

--- a/docs/js/utils/habitable-worlds.js
+++ b/docs/js/utils/habitable-worlds.js
@@ -1,0 +1,22 @@
+import { ORBITAL_FACILITY_CLASSES } from '../facilities/index.js';
+
+const EXCLUDED_KINDS = new Set(Object.keys(ORBITAL_FACILITY_CLASSES));
+
+function countBodies(bodies) {
+  return bodies.reduce((total, body) => {
+    let count = body.isHabitable && !EXCLUDED_KINDS.has(body.kind) ? 1 : 0;
+    if (body.moons?.length) count += countBodies(body.moons);
+    return total + count;
+  }, 0);
+}
+
+export function countHabitableWorlds(galaxy) {
+  return galaxy.systems.reduce((sum, { system }) => {
+    return (
+      sum +
+      system.stars.reduce((starTotal, star) => {
+        return starTotal + countBodies(star.planets || []);
+      }, 0)
+    );
+  }, 0);
+}


### PR DESCRIPTION
## Summary
- factor habitable world counting into reusable utility
- use utility in galaxy overview to exclude orbital facilities from count

## Testing
- `npm test --prefix docs`

------
https://chatgpt.com/codex/tasks/task_e_68944888d66c832aaf6c713f0be0feae