### PR TITLE
Add facility creation tests

### DIFF
--- a/docs/js/facilities/index.js
+++ b/docs/js/facilities/index.js
@@ -27,18 +27,18 @@ export {
 };
 
 export const ORBITAL_FACILITY_CLASSES = {
-  base: Base,
-  shipyard: Shipyard,
-  orbitalMine: OrbitalMine,
-  orbitalManufactory: OrbitalManufactory,
-  orbitalResearch: OrbitalResearch,
-  jumpStation: JumpStation
+  Base,
+  Shipyard,
+  'Orbital Mine': OrbitalMine,
+  'Orbital Manufactory': OrbitalManufactory,
+  'Orbital Research Facility': OrbitalResearch,
+  'Jump Station': JumpStation,
 };
 
 export const SURFACE_FACILITY_CLASSES = {
-  mine: Mine,
-  spaceport: Spaceport,
-  manufactory: Manufactory,
-  research: Research
+  Mine,
+  Spaceport,
+  Manufactory,
+  'Research Facility': Research,
 };
 

--- a/docs/test/facilities-display.test.js
+++ b/docs/test/facilities-display.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { generateMoons } from '../js/objects/moon.js';
+import { createPlanetSidebar } from '../js/components/planet-sidebar.js';
+
+// Verify that an orbital facility can be generated and listed in the sidebar
+// as an orbiting object.
+test('orbital facilities appear in planet sidebar', () => {
+  const planet = {
+    name: 'Test',
+    type: 'rocky',
+    kind: 'planet',
+    distance: 1,
+    radius: 1,
+    mass: 1,
+    gravity: 1,
+    atmosphericPressure: 1,
+    temperature: 300,
+    isHabitable: false,
+    orbitalPeriod: 1,
+    eccentricity: 0,
+    features: ['Base'],
+    resources: {},
+    atmosphere: null,
+    moons: []
+  };
+  const star = { mass: 1 };
+  const origRandom = Math.random;
+  Math.random = () => 0; // ensure deterministic generation with no natural moons
+  planet.moons = generateMoons(star, planet);
+  Math.random = origRandom;
+  // remove feature so it is not listed as a surface object
+  planet.features = [];
+  assert.equal(planet.moons.length, 1);
+  assert.equal(planet.moons[0].kind, 'Base');
+
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+  global.document = dom.window.document;
+  const sidebar = createPlanetSidebar(planet);
+  const html = sidebar.innerHTML;
+  assert.match(html, /Base 1/);
+  delete global.document;
+});
+
+// Verify that surface facilities are listed under Surface Objects in the sidebar
+// when present on a planet.
+test('surface facilities listed in planet sidebar', () => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+  global.document = dom.window.document;
+  const planet = {
+    name: 'Test',
+    type: 'rocky',
+    kind: 'planet',
+    distance: 1,
+    radius: 1,
+    gravity: 1,
+    atmosphericPressure: 1,
+    temperature: 300,
+    isHabitable: false,
+    orbitalPeriod: 1,
+    eccentricity: 0,
+    features: ['Mine', 'Spaceport'],
+    resources: {},
+    atmosphere: null,
+    moons: []
+  };
+  const sidebar = createPlanetSidebar(planet);
+  const html = sidebar.innerHTML;
+  assert.match(html, /<li>Mine<\/li>/);
+  assert.match(html, /<li>Spaceport<\/li>/);
+  delete global.document;
+});

--- a/docs/test/galaxy-habitable-count.test.js
+++ b/docs/test/galaxy-habitable-count.test.js
@@ -46,8 +46,8 @@ const ctxStub = {
 test('displays habitable world count', async () => {
   setupDom();
   const habitableMoon = { isHabitable: true, kind: 'moon', moons: [] };
-  const base = { isHabitable: true, kind: 'base', moons: [] };
-  const shipyard = { isHabitable: true, kind: 'shipyard', moons: [] };
+  const base = { isHabitable: true, kind: 'Base', moons: [] };
+  const shipyard = { isHabitable: true, kind: 'Shipyard', moons: [] };
   const planet = {
     isHabitable: true,
     kind: 'planet',


### PR DESCRIPTION
## Summary
- Map orbital and surface facility lookup keys to their display names
- Add tests confirming orbital facilities generate as moons and surface facilities list in planet sidebar
- Align habitable world count test with updated facility kind names

## Testing
- `cd docs && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68945bd55090832a8bc7180cb709af9b