### PR TITLE
Add facility creation dialog for planetary objects

### DIFF
--- a/docs/js/components/facility-dialog.js
+++ b/docs/js/components/facility-dialog.js
@@ -1,0 +1,77 @@
+import { ORBITAL_FACILITY_CLASSES, SURFACE_FACILITY_CLASSES } from '../facilities/index.js';
+
+function hasFacility(obj, name) {
+  if (SURFACE_FACILITY_CLASSES[name]) {
+    return (obj.features || []).includes(name);
+  }
+  if (ORBITAL_FACILITY_CLASSES[name]) {
+    return (obj.moons || []).some((m) => m.kind === name);
+  }
+  return false;
+}
+
+function canCreate(obj, name) {
+  if (name === 'Spaceport') return true;
+  if (name === 'Base') return (obj.features || []).includes('Spaceport');
+  if (ORBITAL_FACILITY_CLASSES[name]) {
+    return (obj.moons || []).some((m) => m.kind === 'Base');
+  }
+  return true;
+}
+
+function create(obj, name) {
+  if (SURFACE_FACILITY_CLASSES[name]) {
+    obj.features = obj.features || [];
+    obj.features.push(name);
+    return;
+  }
+  if (ORBITAL_FACILITY_CLASSES[name]) {
+    const Facility = ORBITAL_FACILITY_CLASSES[name];
+    const facility = Facility.generate(null, (obj.moons || []).length, obj);
+    if (!obj.moons) obj.moons = [];
+    if (facility) obj.moons.push(facility);
+  }
+}
+
+export function createFacilityDialog(obj, onCreate = null) {
+  const dialog = document.createElement('dialog');
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+
+  const allFacilities = [
+    ...Object.keys(SURFACE_FACILITY_CLASSES),
+    ...Object.keys(ORBITAL_FACILITY_CLASSES),
+  ];
+
+  for (const name of allFacilities) {
+    if (hasFacility(obj, name)) continue;
+    const row = document.createElement('tr');
+    const nameCell = document.createElement('td');
+    nameCell.textContent = name;
+    const actionCell = document.createElement('td');
+    const btn = document.createElement('button');
+    btn.textContent = 'Create';
+    const allowed = canCreate(obj, name);
+    if (!allowed) btn.disabled = true;
+    btn.addEventListener('click', () => {
+      create(obj, name);
+      onCreate?.();
+      dialog.close?.();
+      dialog.remove();
+    });
+    actionCell.appendChild(btn);
+    row.append(nameCell, actionCell);
+    tbody.appendChild(row);
+  }
+
+  table.appendChild(tbody);
+  dialog.appendChild(table);
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => {
+    dialog.close?.();
+    dialog.remove();
+  });
+  dialog.appendChild(closeBtn);
+  return dialog;
+}

--- a/docs/js/components/planet-sidebar.js
+++ b/docs/js/components/planet-sidebar.js
@@ -1,3 +1,5 @@
+import { createFacilityDialog } from './facility-dialog.js';
+
 export function createPlanetSidebar(planet) {
   const container = document.createElement('div');
   container.className = 'planet-sidebar';
@@ -51,6 +53,18 @@ export function createPlanetSidebar(planet) {
     <h3>Orbiting Objects</h3>
     ${moonsTable}
   `;
+  const btn = document.createElement('button');
+  btn.className = 'create-facilities';
+  btn.textContent = 'Create Facilities';
+  btn.addEventListener('click', () => {
+    const dialog = createFacilityDialog(planet, () => {
+      const updated = createPlanetSidebar(planet);
+      container.replaceWith(updated);
+    });
+    document.body.appendChild(dialog);
+    dialog.showModal?.();
+  });
+  container.appendChild(btn);
   return container;
 }
 

--- a/docs/test/facility-creation.test.js
+++ b/docs/test/facility-creation.test.js
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { createPlanetSidebar } from '../js/components/planet-sidebar.js';
+
+const planetTemplate = {
+  name: 'Test',
+  type: 'rocky',
+  kind: 'planet',
+  distance: 1,
+  orbitDistance: 1,
+  radius: 1,
+  gravity: 1,
+  mass: 1,
+  temperature: 300,
+  temperatureSpan: 0,
+  isHabitable: false,
+  orbitalPeriod: 1,
+  features: [],
+  angle: 0,
+  eccentricity: 0,
+  orbitRotation: 0,
+  resources: {},
+  atmosphere: null,
+  atmosphericPressure: 1,
+  moons: []
+};
+
+test('facility creation respects prerequisites', () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  const planet = JSON.parse(JSON.stringify(planetTemplate));
+
+  let sidebar = createPlanetSidebar(planet);
+  document.body.append(sidebar);
+
+  const getButton = (name) => {
+    const dlg = document.querySelector('dialog');
+    const rows = [...dlg.querySelectorAll('tr')];
+    const row = rows.find((r) => r.children[0].textContent === name);
+    return row?.querySelector('button');
+  };
+
+  sidebar.querySelector('.create-facilities').click();
+  let spaceportBtn = getButton('Spaceport');
+  let baseBtn = getButton('Base');
+  let shipyardBtn = getButton('Shipyard');
+  assert.equal(spaceportBtn.disabled, false);
+  assert.equal(baseBtn.disabled, true);
+  assert.equal(shipyardBtn.disabled, true);
+  spaceportBtn.click();
+  assert.ok(planet.features.includes('Spaceport'));
+
+  sidebar = document.querySelector('.planet-sidebar');
+  sidebar.querySelector('.create-facilities').click();
+  baseBtn = getButton('Base');
+  assert.equal(baseBtn.disabled, false);
+  baseBtn.click();
+  assert.ok(planet.moons.some((m) => m.kind === 'Base'));
+
+  sidebar = document.querySelector('.planet-sidebar');
+  sidebar.querySelector('.create-facilities').click();
+  shipyardBtn = getButton('Shipyard');
+  assert.equal(shipyardBtn.disabled, false);
+  shipyardBtn.click();
+  assert.ok(planet.moons.some((m) => m.kind === 'Shipyard'));
+
+  delete global.window;
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- Add dialog component to create missing orbital and surface facilities with dependency checks
- Link "Create Facilities" button in planet/moon sidebar to open dialog and refresh after creation
- Test facility creation workflow and prerequisites

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68946c708144832a94c004794935875d