### PR TITLE
Allow naming facilities and extend toast visibility

### DIFF
--- a/docs/js/components/facility-dialog.js
+++ b/docs/js/components/facility-dialog.js
@@ -32,17 +32,9 @@ function showToast(message) {
 }
 
 function create(obj, name) {
-  if (SURFACE_FACILITY_CLASSES[name]) {
-    obj.features = obj.features || [];
-    obj.features.push(name);
-    return;
-  }
-  if (ORBITAL_FACILITY_CLASSES[name]) {
-    const Facility = ORBITAL_FACILITY_CLASSES[name];
-    const facility = Facility.generate(null, (obj.moons || []).length, obj);
-    if (!obj.moons) obj.moons = [];
-    if (facility) obj.moons.push(facility);
-  }
+  if (!SURFACE_FACILITY_CLASSES[name]) return;
+  obj.features = obj.features || [];
+  obj.features.push(name);
 }
 
 export function createFacilityDialog(obj, onCreate = null) {
@@ -71,8 +63,19 @@ export function createFacilityDialog(obj, onCreate = null) {
       btn.title = reason;
     }
     btn.addEventListener('click', () => {
-      create(obj, name);
-      showToast(`${name} created`);
+      if (ORBITAL_FACILITY_CLASSES[name]) {
+        const Facility = ORBITAL_FACILITY_CLASSES[name];
+        const facility = Facility.generate(null, (obj.moons || []).length, obj);
+        if (!facility) return;
+        const input = window.prompt('Facility name', facility.name);
+        facility.name = input?.trim() || facility.name;
+        if (!obj.moons) obj.moons = [];
+        obj.moons.push(facility);
+        showToast(`${facility.name} created`);
+      } else {
+        create(obj, name);
+        showToast(`${name} created`);
+      }
       onCreate?.();
       dialog.close?.();
       dialog.remove();

--- a/docs/less/base.less
+++ b/docs/less/base.less
@@ -52,7 +52,7 @@ body {
   padding: 0.5rem 1rem;
   border-radius: 4px;
   opacity: 0;
-  animation: fadein 0.5s forwards, fadeout 0.5s forwards 2.5s;
+  animation: fadein 0.5s forwards, fadeout 0.5s forwards 3s;
 }
 
 @keyframes fadein {

--- a/docs/test/facility-creation.test.js
+++ b/docs/test/facility-creation.test.js
@@ -65,16 +65,20 @@ test('facility creation respects prerequisites', () => {
   sidebar = document.querySelector('.planet-sidebar');
   sidebar.querySelector('.create-facilities').click();
   baseBtn = getButton('Base');
+  global.window.prompt = () => 'My Base';
   assert.equal(baseBtn.disabled, false);
   baseBtn.click();
   assert.ok(planet.moons.some((m) => m.kind === 'Base'));
+  assert.ok(planet.moons.some((m) => m.name === 'My Base'));
 
   sidebar = document.querySelector('.planet-sidebar');
   sidebar.querySelector('.create-facilities').click();
   shipyardBtn = getButton('Shipyard');
+  global.window.prompt = () => 'My Shipyard';
   assert.equal(shipyardBtn.disabled, false);
   shipyardBtn.click();
   assert.ok(planet.moons.some((m) => m.kind === 'Shipyard'));
+  assert.ok(planet.moons.some((m) => m.name === 'My Shipyard'));
 
   delete global.window;
   delete global.document;


### PR DESCRIPTION
## Summary
- extend facility creation toast to remain visible longer
- prompt for a custom facility name before creation
- update tests for customizable facility names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689471afd768832aba7bf2a9800c1808