### PR TITLE
Add facility storage and craft infrastructure

### DIFF
--- a/docs/js/components/facility-dialog.js
+++ b/docs/js/components/facility-dialog.js
@@ -44,7 +44,7 @@ function create(obj, name, facilityName) {
   if (!SURFACE_FACILITY_CLASSES[name]) return;
   if (obj.type === 'gas') return;
   obj.features = obj.features || [];
-  obj.features.push({ kind: name, name: facilityName });
+  obj.features.push({ kind: name, name: facilityName, storage: [], features: [] });
 }
 
 export function createFacilityDialog(obj, onCreate = null) {

--- a/docs/js/facilities/facility.js
+++ b/docs/js/facilities/facility.js
@@ -13,7 +13,13 @@ const FACILITY_ATMOSPHERIC_PRESSURE = 1;
 const POPULATION_MIN = 100;
 const POPULATION_MAX = 1000;
 
-export class Facility extends StellarObject {}
+export class Facility extends StellarObject {
+  constructor(props = {}) {
+    super(props);
+    this.storage = props.storage || [];
+    this.features = props.features || [];
+  }
+}
 
 export class OrbitalFacility extends Facility {
   static generate(star, orbitIndex, parent) {
@@ -44,6 +50,7 @@ export class OrbitalFacility extends Facility {
       isHabitable: true,
       orbitalPeriod,
       features: [],
+      storage: [],
       angle,
       eccentricity,
       orbitRotation,

--- a/docs/js/facilities/index.js
+++ b/docs/js/facilities/index.js
@@ -1,4 +1,5 @@
 import { Facility, OrbitalFacility, SurfaceFacility } from './facility.js';
+import { Storage } from './storage.js';
 import { Base } from './orbital/base.js';
 import { Shipyard } from './orbital/shipyard.js';
 import { OrbitalMine } from './orbital/orbital-mine.js';
@@ -14,6 +15,7 @@ export {
   Facility,
   OrbitalFacility,
   SurfaceFacility,
+  Storage,
   Base,
   Shipyard,
   OrbitalMine,

--- a/docs/js/facilities/storage.js
+++ b/docs/js/facilities/storage.js
@@ -1,0 +1,7 @@
+export class Storage {
+  constructor(type, subtype, items = []) {
+    this.type = type;
+    this.subtype = subtype;
+    this.items = items;
+  }
+}

--- a/docs/js/objects/craft.js
+++ b/docs/js/objects/craft.js
@@ -1,0 +1,14 @@
+export class Craft {
+  constructor(mass, acceleration, name, speed) {
+    this.mass = mass;
+    this.acceleration = acceleration;
+    this.name = name;
+    this.speed = speed;
+  }
+}
+
+export class Probe extends Craft {
+  constructor(mass, acceleration, name, speed) {
+    super(mass, acceleration, name, speed);
+  }
+}

--- a/docs/test/facility-storage.test.js
+++ b/docs/test/facility-storage.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Base } from '../js/facilities/orbital/base.js';
+import { Storage } from '../js/facilities/storage.js';
+import { Craft, Probe } from '../js/objects/craft.js';
+
+test('facilities include storage and features arrays', () => {
+  const parent = { temperature: 300, distance: 1, mass: 1 };
+  const facility = Base.generate(null, 0, parent);
+  assert.ok(Array.isArray(facility.storage));
+  assert.ok(Array.isArray(facility.features));
+});
+
+test('storage can hold resources and crafts', () => {
+  const ammoniaStore = new Storage('resource', 'ammonia', [50]);
+  assert.equal(ammoniaStore.items.length, 1);
+  assert.equal(ammoniaStore.items[0], 50);
+
+  const probeStore = new Storage('crafts', 'probe');
+  const probe = new Probe(1, 1, 'P1', 10);
+  probeStore.items.push(probe);
+  assert.strictEqual(probeStore.items[0], probe);
+  assert.ok(probe instanceof Craft);
+});


### PR DESCRIPTION
## Summary
- allow facilities to maintain `storage` and `features` arrays
- support typed storage units and simple craft model (Craft/Probe)
- cover new behavior with tests

## Testing
- `cd docs && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894a1517a68832a92c76cf0c5da5a3c